### PR TITLE
feat(pi): add workspace switcher extension

### DIFF
--- a/shared/stow/pi/.pi/agent/extensions/statusline.ts
+++ b/shared/stow/pi/.pi/agent/extensions/statusline.ts
@@ -38,22 +38,29 @@ export default function statusline(pi: ExtensionAPI) {
 
     let dirty = false;
     let disposed = false;
+    let requestRender: (() => void) | undefined;
 
     const refreshDirty = async () => {
       const result = await pi.exec("git", ["status", "--porcelain"], { cwd: ctx.cwd, timeout: 5_000 });
       if (disposed) return;
-      dirty = result.code === 0 && result.stdout.trim().length > 0;
+      const nextDirty = result.code === 0 && result.stdout.trim().length > 0;
+      if (nextDirty !== dirty) {
+        dirty = nextDirty;
+        requestRender?.();
+      }
     };
 
     void refreshDirty();
     const dirtyTimer = setInterval(() => void refreshDirty(), DIRTY_REFRESH_INTERVAL_MS);
 
     ctx.ui.setFooter((tui, theme, footerData) => {
+      requestRender = () => tui.requestRender();
       const unsubscribeBranch = footerData.onBranchChange(() => tui.requestRender());
 
       return {
         dispose() {
           disposed = true;
+          requestRender = undefined;
           clearInterval(dirtyTimer);
           unsubscribeBranch();
         },

--- a/shared/stow/pi/.pi/agent/extensions/statusline.ts
+++ b/shared/stow/pi/.pi/agent/extensions/statusline.ts
@@ -86,7 +86,9 @@ export default function statusline(pi: ExtensionAPI) {
             usageParts.push(costStr);
           }
 
-          const extensionStatuses = footerData.getExtensionStatuses?.() ?? [];
+          const extensionStatuses = Array.from(footerData.getExtensionStatuses?.() ?? new Map<string, string>())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([, text]) => text);
 
           const line = joinStyled(
             [

--- a/shared/stow/pi/.pi/agent/extensions/statusline.ts
+++ b/shared/stow/pi/.pi/agent/extensions/statusline.ts
@@ -86,11 +86,14 @@ export default function statusline(pi: ExtensionAPI) {
             usageParts.push(costStr);
           }
 
+          const extensionStatuses = footerData.getExtensionStatuses?.() ?? [];
+
           const line = joinStyled(
             [
               theme.fg("accent", formatModel(ctx.model)),
               contextText,
               `${theme.fg("mdCode", directory)}${branchText}`,
+              ...extensionStatuses,
               usageParts.length > 0 ? theme.fg("dim", usageParts.join(" ")) : "",
             ],
             separator,

--- a/shared/stow/pi/.pi/agent/extensions/statusline.ts
+++ b/shared/stow/pi/.pi/agent/extensions/statusline.ts
@@ -39,6 +39,7 @@ export default function statusline(pi: ExtensionAPI) {
     let dirty = false;
     let disposed = false;
     let requestRender: (() => void) | undefined;
+    let dirtyTimer: ReturnType<typeof setInterval> | undefined;
 
     const refreshDirty = async () => {
       const result = await pi.exec("git", ["status", "--porcelain"], { cwd: ctx.cwd, timeout: 5_000 });
@@ -50,18 +51,18 @@ export default function statusline(pi: ExtensionAPI) {
       }
     };
 
-    void refreshDirty();
-    const dirtyTimer = setInterval(() => void refreshDirty(), DIRTY_REFRESH_INTERVAL_MS);
-
     ctx.ui.setFooter((tui, theme, footerData) => {
       requestRender = () => tui.requestRender();
+      dirtyTimer ??= setInterval(() => void refreshDirty(), DIRTY_REFRESH_INTERVAL_MS);
+      void refreshDirty();
       const unsubscribeBranch = footerData.onBranchChange(() => tui.requestRender());
 
       return {
         dispose() {
           disposed = true;
           requestRender = undefined;
-          clearInterval(dirtyTimer);
+          if (dirtyTimer) clearInterval(dirtyTimer);
+          dirtyTimer = undefined;
           unsubscribeBranch();
         },
         invalidate() {},

--- a/shared/stow/pi/.pi/agent/extensions/workspace-switcher.ts
+++ b/shared/stow/pi/.pi/agent/extensions/workspace-switcher.ts
@@ -1,0 +1,324 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, resolve } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, isToolCallEventType } from "@mariozechner/pi-coding-agent";
+import type { AutocompleteItem } from "@mariozechner/pi-tui";
+
+interface WorkspaceConfig {
+  default?: string;
+  aliases?: Record<string, string>;
+  workspaces?: Record<string, string>;
+}
+
+interface Workspace {
+  alias: string;
+  path: string;
+}
+
+type WorkspaceState = Workspace | null;
+
+const STATE_ENTRY = "workspace-switcher-state";
+const STATUS_KEY = "workspace";
+
+function expandHome(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return join(homedir(), path.slice(2));
+  return path;
+}
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function normalizeConfig(raw: unknown): WorkspaceConfig {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const record = raw as Record<string, unknown>;
+
+  const aliases: Record<string, string> = {};
+
+  // Compact form: { "core": "/repo", "community": "/repo2" }
+  for (const [key, value] of Object.entries(record)) {
+    if (typeof value === "string" && key !== "default") {
+      aliases[key] = value;
+    }
+  }
+
+  // Explicit forms: { aliases: {...} } or { workspaces: {...} }
+  for (const field of ["aliases", "workspaces"] as const) {
+    const nested = record[field];
+    if (!nested || typeof nested !== "object" || Array.isArray(nested)) continue;
+    for (const [key, value] of Object.entries(nested as Record<string, unknown>)) {
+      if (typeof value === "string") aliases[key] = value;
+    }
+  }
+
+  return {
+    default: typeof record.default === "string" ? record.default : undefined,
+    aliases,
+  };
+}
+
+function loadWorkspaceConfig(cwd: string): WorkspaceConfig {
+  const paths = [join(getAgentDir(), "workspaces.json"), join(cwd, ".pi", "workspaces.json")];
+  const merged: WorkspaceConfig = { aliases: {} };
+
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+    try {
+      const config = normalizeConfig(loadJson(path));
+      Object.assign(merged.aliases, config.aliases ?? {}, config.workspaces ?? {});
+      if (config.default) merged.default = config.default;
+    } catch (error) {
+      console.error(`Failed to load workspace config from ${path}: ${error}`);
+    }
+  }
+
+  return merged;
+}
+
+function workspacesFromConfig(config: WorkspaceConfig): Workspace[] {
+  const aliases = config.aliases ?? {};
+  return Object.entries(aliases)
+    .map(([alias, path]) => ({ alias, path: resolve(expandHome(path)) }))
+    .filter((workspace) => isExistingDirectory(workspace.path))
+    .sort((a, b) => a.alias.localeCompare(b.alias));
+}
+
+function isExistingDirectory(path: string): boolean {
+  try {
+    return existsSync(path) && statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isRelativeFilesystemPath(path: string): boolean {
+  if (!path) return false;
+  if (isAbsolute(path)) return false;
+  if (path === "~" || path.startsWith("~/")) return false;
+  // Avoid rewriting URI-ish values if some custom tool also has a `path` field.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(path)) return false;
+  return true;
+}
+
+function resolveAgainstWorkspace(path: string, workspace: Workspace): string {
+  return resolve(workspace.path, path);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function shortPath(path: string): string {
+  const home = homedir();
+  return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
+function describeWorkspace(workspace: Workspace): string {
+  return `${workspace.alias} (${shortPath(workspace.path)})`;
+}
+
+function statusText(ctx: ExtensionContext, workspace: WorkspaceState): string | undefined {
+  if (!workspace) return undefined;
+  return ctx.ui.theme.fg("accent", `repo:${workspace.alias}`);
+}
+
+function setActiveWorkspace(ctx: ExtensionContext, workspace: WorkspaceState) {
+  activeWorkspace = workspace;
+  piAppendWorkspaceState(workspace);
+  updateStatus(ctx);
+}
+
+let activeWorkspace: WorkspaceState = null;
+let workspaces: Workspace[] = [];
+let workspaceConfig: WorkspaceConfig = {};
+let appendState: ((customType: string, data?: unknown) => void) | null = null;
+
+function piAppendWorkspaceState(workspace: WorkspaceState) {
+  appendState?.(STATE_ENTRY, workspace ? { alias: workspace.alias, path: workspace.path } : { alias: null, path: null });
+}
+
+function updateStatus(ctx: ExtensionContext) {
+  if (!ctx.hasUI) return;
+  ctx.ui.setStatus(STATUS_KEY, statusText(ctx, activeWorkspace));
+}
+
+function findWorkspace(query: string): Workspace | undefined {
+  const trimmed = query.trim();
+  if (!trimmed) return undefined;
+
+  const exact = workspaces.find((workspace) => workspace.alias === trimmed || workspace.path === expandHome(trimmed));
+  if (exact) return exact;
+
+  const lower = trimmed.toLowerCase();
+  const fuzzy = workspaces.find(
+    (workspace) => workspace.alias.toLowerCase().includes(lower) || workspace.path.toLowerCase().includes(lower),
+  );
+  if (fuzzy) return fuzzy;
+
+  const maybePath = resolve(expandHome(trimmed));
+  if (isExistingDirectory(maybePath)) {
+    return { alias: basename(maybePath) || maybePath, path: maybePath };
+  }
+
+  return undefined;
+}
+
+function completionItems(prefix: string): AutocompleteItem[] | null {
+  const builtins = ["clear", "list", "status"].map((value) => ({ value, label: value }));
+  const configured = workspaces.map((workspace) => ({
+    value: workspace.alias,
+    label: workspace.alias,
+    description: workspace.path,
+  }));
+  const lower = prefix.trim().toLowerCase();
+  const items = [...builtins, ...configured].filter(
+    (item) => !lower || item.value.toLowerCase().includes(lower) || item.label.toLowerCase().includes(lower),
+  );
+  return items.length > 0 ? items : null;
+}
+
+function latestPersistedWorkspace(ctx: ExtensionContext): WorkspaceState | undefined {
+  const entry = ctx.sessionManager
+    .getEntries()
+    .filter((e: { type: string; customType?: string }) => e.type === "custom" && e.customType === STATE_ENTRY)
+    .pop() as { data?: { alias?: unknown; path?: unknown } } | undefined;
+
+  if (!entry) return undefined;
+  if (entry.data?.alias === null || entry.data?.path === null) return null;
+  if (typeof entry.data?.alias === "string" && typeof entry.data?.path === "string") {
+    return { alias: entry.data.alias, path: entry.data.path };
+  }
+  return undefined;
+}
+
+async function selectWorkspace(ctx: ExtensionContext): Promise<WorkspaceState | undefined> {
+  if (!ctx.hasUI) return undefined;
+  const choices = ["(clear)", ...workspaces.map(describeWorkspace)];
+  const choice = await ctx.ui.select("Select active workspace", choices);
+  if (!choice) return undefined;
+  if (choice === "(clear)") return null;
+  return workspaces.find((workspace) => describeWorkspace(workspace) === choice);
+}
+
+function mutateToolInputForWorkspace(event: { toolName: string; input: unknown }, workspace: Workspace) {
+  if (isToolCallEventType("bash", event)) {
+    event.input.command = `cd ${shellQuote(workspace.path)} && ${event.input.command}`;
+    return;
+  }
+
+  if (!event.input || typeof event.input !== "object") return;
+  const input = event.input as Record<string, unknown>;
+
+  if (["read", "write", "edit"].includes(event.toolName) && typeof input.path === "string" && isRelativeFilesystemPath(input.path)) {
+    input.path = resolveAgainstWorkspace(input.path, workspace);
+  }
+
+  // Quality-of-life for common cwd-aware extension tools without making them required.
+  if (event.toolName === "lsp_diagnostics") {
+    if (typeof input.path === "string" && isRelativeFilesystemPath(input.path)) {
+      input.path = resolveAgainstWorkspace(input.path, workspace);
+    }
+    if (typeof input.cwd !== "string") input.cwd = workspace.path;
+  }
+
+  if ((event.toolName === "peb_plan" || event.toolName === "peb_sync_github") && typeof input.repo !== "string") {
+    input.repo = workspace.path;
+  }
+}
+
+export default function workspaceSwitcher(pi: ExtensionAPI) {
+  appendState = pi.appendEntry.bind(pi);
+
+  pi.on("session_start", (_event, ctx) => {
+    workspaceConfig = loadWorkspaceConfig(ctx.cwd);
+    workspaces = workspacesFromConfig(workspaceConfig);
+
+    const restored = latestPersistedWorkspace(ctx);
+    if (restored !== undefined) {
+      activeWorkspace = restored && isExistingDirectory(restored.path) ? restored : null;
+    } else if (workspaceConfig.default) {
+      activeWorkspace = findWorkspace(workspaceConfig.default) ?? null;
+    } else {
+      activeWorkspace = null;
+    }
+
+    updateStatus(ctx);
+  });
+
+  pi.on("session_shutdown", (_event, ctx) => {
+    if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+  });
+
+  pi.registerCommand("repo", {
+    description: "Set an active workspace for relative tool paths and bash cwd",
+    getArgumentCompletions: completionItems,
+    handler: async (args, ctx) => {
+      workspaceConfig = loadWorkspaceConfig(ctx.cwd);
+      workspaces = workspacesFromConfig(workspaceConfig);
+      const arg = (args ?? "").trim();
+
+      if (arg === "clear" || arg === "none" || arg === "off") {
+        setActiveWorkspace(ctx, null);
+        ctx.ui.notify("Workspace cleared; tools will use Pi launch cwd", "info");
+        return;
+      }
+
+      if (arg === "list") {
+        const body = workspaces.length > 0
+          ? workspaces.map((workspace) => `- ${describeWorkspace(workspace)}`).join("\n")
+          : "No workspaces configured. Add ~/.pi/agent/workspaces.json.";
+        ctx.ui.notify(body, "info");
+        return;
+      }
+
+      if (arg === "status") {
+        ctx.ui.notify(
+          activeWorkspace
+            ? `Active workspace: ${describeWorkspace(activeWorkspace)}`
+            : `No active workspace; tools use Pi launch cwd: ${shortPath(ctx.cwd)}`,
+          "info",
+        );
+        return;
+      }
+
+      if (!arg) {
+        const selected = await selectWorkspace(ctx);
+        if (selected === undefined) {
+          ctx.ui.notify(
+            activeWorkspace
+              ? `Active workspace: ${describeWorkspace(activeWorkspace)}`
+              : `No active workspace. Available: ${workspaces.map((w) => w.alias).join(", ") || "none"}`,
+            "info",
+          );
+          return;
+        }
+        setActiveWorkspace(ctx, selected);
+        ctx.ui.notify(selected ? `Active workspace: ${describeWorkspace(selected)}` : "Workspace cleared", "info");
+        return;
+      }
+
+      const workspace = findWorkspace(arg);
+      if (!workspace) {
+        ctx.ui.notify(`Unknown workspace: ${arg}. Run /repo list to see configured aliases.`, "error");
+        return;
+      }
+
+      setActiveWorkspace(ctx, workspace);
+      ctx.ui.notify(`Active workspace: ${describeWorkspace(workspace)}`, "info");
+    },
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    if (!activeWorkspace) return;
+    return {
+      systemPrompt: `${event.systemPrompt}\n\nWorkspace switcher is active. Treat ${activeWorkspace.alias} (${activeWorkspace.path}) as the active workspace for relative paths. The workspace-switcher extension rewrites relative read/write/edit paths and bash commands to execute from that directory. Pi's launch cwd remains ${ctx.cwd}.`,
+    };
+  });
+
+  pi.on("tool_call", async (event) => {
+    if (!activeWorkspace) return;
+    mutateToolInputForWorkspace(event, activeWorkspace);
+  });
+}

--- a/shared/stow/pi/.pi/agent/extensions/workspace-switcher.ts
+++ b/shared/stow/pi/.pi/agent/extensions/workspace-switcher.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, isAbsolute, join, resolve } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { getAgentDir, isToolCallEventType } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import type { AutocompleteItem } from "@mariozechner/pi-tui";
 
 interface WorkspaceConfig {
@@ -61,20 +61,21 @@ function normalizeConfig(raw: unknown): WorkspaceConfig {
 
 function loadWorkspaceConfig(cwd: string): WorkspaceConfig {
   const paths = [join(getAgentDir(), "workspaces.json"), join(cwd, ".pi", "workspaces.json")];
-  const merged: WorkspaceConfig = { aliases: {} };
+  const aliases: Record<string, string> = {};
+  let defaultWorkspace: string | undefined;
 
   for (const path of paths) {
     if (!existsSync(path)) continue;
     try {
       const config = normalizeConfig(loadJson(path));
-      Object.assign(merged.aliases, config.aliases ?? {}, config.workspaces ?? {});
-      if (config.default) merged.default = config.default;
+      Object.assign(aliases, config.aliases ?? {}, config.workspaces ?? {});
+      if (config.default) defaultWorkspace = config.default;
     } catch (error) {
       console.error(`Failed to load workspace config from ${path}: ${error}`);
     }
   }
 
-  return merged;
+  return { aliases, default: defaultWorkspace };
 }
 
 function workspacesFromConfig(config: WorkspaceConfig): Workspace[] {
@@ -202,24 +203,45 @@ async function selectWorkspace(ctx: ExtensionContext): Promise<WorkspaceState | 
   return workspaces.find((workspace) => describeWorkspace(workspace) === choice);
 }
 
+function resolveOptionalPathInput(input: Record<string, unknown>, workspace: Workspace) {
+  if (typeof input.path === "string") {
+    if (isRelativeFilesystemPath(input.path)) {
+      input.path = resolveAgainstWorkspace(input.path, workspace);
+    }
+  } else {
+    input.path = workspace.path;
+  }
+}
+
+function resolveRequiredPathInput(input: Record<string, unknown>, workspace: Workspace) {
+  if (typeof input.path === "string" && isRelativeFilesystemPath(input.path)) {
+    input.path = resolveAgainstWorkspace(input.path, workspace);
+  }
+}
+
 function mutateToolInputForWorkspace(event: { toolName: string; input: unknown }, workspace: Workspace) {
-  if (isToolCallEventType("bash", event)) {
-    event.input.command = `cd ${shellQuote(workspace.path)} && ${event.input.command}`;
+  if (event.toolName === "bash" && event.input && typeof event.input === "object") {
+    const input = event.input as Record<string, unknown>;
+    if (typeof input.command === "string") {
+      input.command = `cd ${shellQuote(workspace.path)} && ${input.command}`;
+    }
     return;
   }
 
   if (!event.input || typeof event.input !== "object") return;
   const input = event.input as Record<string, unknown>;
 
-  if (["read", "write", "edit"].includes(event.toolName) && typeof input.path === "string" && isRelativeFilesystemPath(input.path)) {
-    input.path = resolveAgainstWorkspace(input.path, workspace);
+  if (["read", "write", "edit"].includes(event.toolName)) {
+    resolveRequiredPathInput(input, workspace);
+  }
+
+  if (["ls", "grep", "find"].includes(event.toolName)) {
+    resolveOptionalPathInput(input, workspace);
   }
 
   // Quality-of-life for common cwd-aware extension tools without making them required.
   if (event.toolName === "lsp_diagnostics") {
-    if (typeof input.path === "string" && isRelativeFilesystemPath(input.path)) {
-      input.path = resolveAgainstWorkspace(input.path, workspace);
-    }
+    resolveRequiredPathInput(input, workspace);
     if (typeof input.cwd !== "string") input.cwd = workspace.path;
   }
 
@@ -238,9 +260,9 @@ export default function workspaceSwitcher(pi: ExtensionAPI) {
     const restored = latestPersistedWorkspace(ctx);
     if (restored !== undefined) {
       activeWorkspace = restored && isExistingDirectory(restored.path) ? restored : null;
-    } else if (workspaceConfig.default) {
-      activeWorkspace = findWorkspace(workspaceConfig.default) ?? null;
     } else {
+      // Require an explicit /repo selection before rewriting tool calls. This avoids
+      // a project-local .pi/workspaces.json silently redirecting writes or bash.
       activeWorkspace = null;
     }
 
@@ -313,7 +335,7 @@ export default function workspaceSwitcher(pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event, ctx) => {
     if (!activeWorkspace) return;
     return {
-      systemPrompt: `${event.systemPrompt}\n\nWorkspace switcher is active. Treat ${activeWorkspace.alias} (${activeWorkspace.path}) as the active workspace for relative paths. The workspace-switcher extension rewrites relative read/write/edit paths and bash commands to execute from that directory. Pi's launch cwd remains ${ctx.cwd}.`,
+      systemPrompt: `${event.systemPrompt}\n\nWorkspace switcher is active. Treat ${activeWorkspace.alias} (${activeWorkspace.path}) as the active workspace for relative paths. The workspace-switcher extension rewrites relative read/write/edit/ls/grep/find paths and bash commands to execute from that directory. Pi's launch cwd remains ${ctx.cwd}.`,
     };
   });
 

--- a/shared/stow/pi/.pi/agent/extensions/workspace-switcher.ts
+++ b/shared/stow/pi/.pi/agent/extensions/workspace-switcher.ts
@@ -103,6 +103,12 @@ function isRelativeFilesystemPath(path: string): boolean {
   return true;
 }
 
+function normalizeToolPath(path: string): string {
+  // Pi's built-in tools accept @path from file-reference completions and strip
+  // the leading @ before resolving. Preserve that behavior before rewriting.
+  return path.startsWith("@") ? path.slice(1) : path;
+}
+
 function resolveAgainstWorkspace(path: string, workspace: Workspace): string {
   return resolve(workspace.path, path);
 }
@@ -182,7 +188,7 @@ function completionItems(prefix: string): AutocompleteItem[] | null {
 
 function latestPersistedWorkspace(ctx: ExtensionContext): WorkspaceState | undefined {
   const entry = ctx.sessionManager
-    .getEntries()
+    .getBranch()
     .filter((e: { type: string; customType?: string }) => e.type === "custom" && e.customType === STATE_ENTRY)
     .pop() as { data?: { alias?: unknown; path?: unknown } } | undefined;
 
@@ -205,17 +211,17 @@ async function selectWorkspace(ctx: ExtensionContext): Promise<WorkspaceState | 
 
 function resolveOptionalPathInput(input: Record<string, unknown>, workspace: Workspace) {
   if (typeof input.path === "string") {
-    if (isRelativeFilesystemPath(input.path)) {
-      input.path = resolveAgainstWorkspace(input.path, workspace);
-    }
+    const path = normalizeToolPath(input.path);
+    input.path = isRelativeFilesystemPath(path) ? resolveAgainstWorkspace(path, workspace) : path;
   } else {
     input.path = workspace.path;
   }
 }
 
 function resolveRequiredPathInput(input: Record<string, unknown>, workspace: Workspace) {
-  if (typeof input.path === "string" && isRelativeFilesystemPath(input.path)) {
-    input.path = resolveAgainstWorkspace(input.path, workspace);
+  if (typeof input.path === "string") {
+    const path = normalizeToolPath(input.path);
+    input.path = isRelativeFilesystemPath(path) ? resolveAgainstWorkspace(path, workspace) : path;
   }
 }
 

--- a/shared/stow/pi/.pi/agent/workspaces.json
+++ b/shared/stow/pi/.pi/agent/workspaces.json
@@ -1,0 +1,5 @@
+{
+  "core": "/Users/brandon/personal/ricekit.git/main",
+  "community": "/Users/brandon/personal/ricekit-community",
+  "dotfiles": "/Users/brandon/.dotfiles"
+}

--- a/shared/stow/pi/README.md
+++ b/shared/stow/pi/README.md
@@ -9,6 +9,7 @@ Stowing `shared/stow/pi` into `$HOME` creates:
 - `~/.pi/agent/AGENTS.md` — global pi instructions
 - `~/.pi/agent/extensions/` — custom pi extensions
 - `~/.pi/agent/mcp.json` — lazy MCP server configuration
+- `~/.pi/agent/workspaces.json` — named workspace aliases for the `/repo` command
 
 ## Extensions
 
@@ -18,6 +19,26 @@ Stowing `shared/stow/pi` into `$HOME` creates:
 - `lsp.ts` — adds `lsp_diagnostics` with per-language/per-root server isolation for worktrees and subagents.
 - `mcp.ts` — adds lazy MCP tools plus the `/mcp` command.
 - `pebble-orchestrator.ts` — plans and burns down Pebbles-backed work with git worktrees and Pi subagents.
+- `workspace-switcher.ts` — adds `/repo` to set an active workspace so relative tool paths and bash commands run from that repo.
+
+## Workspace switcher
+
+Commands:
+
+```text
+/repo                    # select/show active workspace
+/repo core               # use /Users/brandon/personal/ricekit.git/main
+/repo community          # use /Users/brandon/personal/ricekit-community
+/repo dotfiles           # use /Users/brandon/.dotfiles
+/repo /absolute/path     # use an ad-hoc directory
+/repo list               # list configured aliases
+/repo status             # show current active workspace
+/repo clear              # return to Pi launch cwd behavior
+```
+
+When a workspace is active, `workspace-switcher.ts` rewrites relative `read`, `write`, and `edit` paths to that workspace and prefixes `bash` commands with `cd <workspace> &&`. It also nudges `lsp_diagnostics`, `peb_plan`, and `peb_sync_github` to use the active workspace when their cwd/repo argument is omitted. Absolute paths are left unchanged.
+
+Aliases live in `~/.pi/agent/workspaces.json` as a simple map from name to path.
 
 ## Pebble orchestrator
 

--- a/shared/stow/pi/README.md
+++ b/shared/stow/pi/README.md
@@ -36,7 +36,7 @@ Commands:
 /repo clear              # return to Pi launch cwd behavior
 ```
 
-When a workspace is active, `workspace-switcher.ts` rewrites relative `read`, `write`, and `edit` paths to that workspace and prefixes `bash` commands with `cd <workspace> &&`. It also nudges `lsp_diagnostics`, `peb_plan`, and `peb_sync_github` to use the active workspace when their cwd/repo argument is omitted. Absolute paths are left unchanged.
+When a workspace is active, `workspace-switcher.ts` rewrites relative `read`, `write`, `edit`, `ls`, `grep`, and `find` paths to that workspace and prefixes `bash` commands with `cd <workspace> &&`. It also nudges `lsp_diagnostics`, `peb_plan`, and `peb_sync_github` to use the active workspace when their cwd/repo argument is omitted. Absolute paths are left unchanged.
 
 Aliases live in `~/.pi/agent/workspaces.json` as a simple map from name to path.
 


### PR DESCRIPTION
## Summary

- add `workspace-switcher.ts` with `/repo` active-workspace command
- add `workspaces.json` aliases for core/community/dotfiles
- include extension statuses in the custom statusline
- document workspace switcher usage

## Validation

- smoke-tested `/repo core` with `bash pwd` executing from RiceKit core
- temp-file assertions for relative `write`, `read`, and `edit`
- temp workspace assertions for `ls`, `grep`, and `find` with omitted path
- temp workspace assertion for `@path` read normalization
- repeated subagent reviews; final review ready to merge

Refs: dotfiles-bdt