### PR TITLE
chore(pi): add extension tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ shared/stow/pi/.pi/agent/.turbo/
 shared/stow/pi/.pi/agent/packages/*/.turbo/
 shared/stow/pi/.pi/agent/extensions/node_modules/
 shared/stow/pi/.pi/agent/extensions/.turbo/
+shared/stow/pi/.pi/agent/extensions/coverage/
 
 # Runtime symlink managed by omarchy theme-set hook / install.sh
 shared/stow/nvim/.config/nvim/lua/plugins/theme.lua

--- a/shared/stow/pi/.pi/agent/extensions/.oxfmtrc.json
+++ b/shared/stow/pi/.pi/agent/extensions/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://oxc.rs/oxfmt.schema.json"
+}

--- a/shared/stow/pi/.pi/agent/extensions/imagegen.ts
+++ b/shared/stow/pi/.pi/agent/extensions/imagegen.ts
@@ -1,10 +1,10 @@
 import { mkdir, readFile, stat } from "node:fs/promises";
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { StringEnum } from "@mariozechner/pi-ai";
-import type { ExecResult, ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { withFileMutationQueue } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { ExecResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 type ImageFormat = "png" | "jpeg" | "webp";
@@ -36,12 +36,14 @@ const GenerateImageParams = Type.Object({
   ),
   model: Type.Optional(
     Type.String({
-      description: "Ignored for the Codex-backed implementation; kept for compatibility with prior generate_image calls.",
+      description:
+        "Ignored for the Codex-backed implementation; kept for compatibility with prior generate_image calls.",
     }),
   ),
   size: Type.Optional(
     Type.String({
-      description: "Desired image size/aspect ratio, e.g. 1024x1024, 1536x1024, 1024x1536, or auto.",
+      description:
+        "Desired image size/aspect ratio, e.g. 1024x1024, 1536x1024, 1024x1536, or auto.",
       default: "1024x1024",
     }),
   ),
@@ -61,14 +63,21 @@ const GenerateImageParams = Type.Object({
       default: DEFAULT_FORMAT,
     }),
   ),
-  timeoutMs: Type.Optional(Type.Number({ description: `Codex execution timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.` })),
+  timeoutMs: Type.Optional(
+    Type.Number({
+      description: `Codex execution timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.`,
+    }),
+  ),
 });
 
 function stripAt(path: string): string {
   return path.startsWith("@") ? path.slice(1) : path;
 }
 
-function inferOutputFormat(outputPath: string | undefined, requestedFormat: ImageFormat | undefined): ImageFormat {
+function inferOutputFormat(
+  outputPath: string | undefined,
+  requestedFormat: ImageFormat | undefined,
+): ImageFormat {
   if (requestedFormat) return requestedFormat;
 
   const extension = extname(stripAt(outputPath?.trim() ?? "")).toLowerCase();
@@ -77,7 +86,11 @@ function inferOutputFormat(outputPath: string | undefined, requestedFormat: Imag
   return DEFAULT_FORMAT;
 }
 
-function resolveOutputPath(cwd: string, outputPath: string | undefined, outputFormat: ImageFormat): string {
+function resolveOutputPath(
+  cwd: string,
+  outputPath: string | undefined,
+  outputFormat: ImageFormat,
+): string {
   const path = outputPath?.trim()
     ? stripAt(outputPath.trim())
     : `${DEFAULT_OUTPUT_DIR}/image-${new Date().toISOString().replace(/[:.]/g, "-")}.${outputFormat}`;
@@ -122,19 +135,33 @@ After saving, verify the destination with a filesystem check such as \`file ${pa
 }
 
 function detectImageFormat(bytes: Buffer): string | undefined {
-  if (bytes.length >= 8 && bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) return "png";
-  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "jpeg";
-  if (bytes.length >= 12 && bytes.subarray(0, 4).toString("ascii") === "RIFF" && bytes.subarray(8, 12).toString("ascii") === "WEBP") return "webp";
+  if (
+    bytes.length >= 8 &&
+    bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+  )
+    return "png";
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff)
+    return "jpeg";
+  if (
+    bytes.length >= 12 &&
+    bytes.subarray(0, 4).toString("ascii") === "RIFF" &&
+    bytes.subarray(8, 12).toString("ascii") === "WEBP"
+  )
+    return "webp";
   return undefined;
 }
 
-async function validateGeneratedImage(path: string): Promise<{ bytes: number; detectedFormat: string }> {
+async function validateGeneratedImage(
+  path: string,
+): Promise<{ bytes: number; detectedFormat: string }> {
   const fileStat = await stat(path);
-  if (!fileStat.isFile() || fileStat.size === 0) throw new Error(`Codex did not create a non-empty file at ${path}.`);
+  if (!fileStat.isFile() || fileStat.size === 0)
+    throw new Error(`Codex did not create a non-empty file at ${path}.`);
 
   const header = await readFile(path);
   const detectedFormat = detectImageFormat(header);
-  if (!detectedFormat) throw new Error(`Generated file is not a recognized PNG, JPEG, or WebP bitmap: ${path}`);
+  if (!detectedFormat)
+    throw new Error(`Generated file is not a recognized PNG, JPEG, or WebP bitmap: ${path}`);
 
   return { bytes: fileStat.size, detectedFormat };
 }
@@ -155,7 +182,8 @@ export default function (pi: ExtensionAPI) {
     label: "Generate Image",
     description:
       "Generate a bitmap image by delegating to Codex CLI's hosted image generation capability, then save it to disk. Requires Codex CLI to be installed and logged in.",
-    promptSnippet: "Generate bitmap images by delegating to Codex CLI's hosted image generation and save them to local files.",
+    promptSnippet:
+      "Generate bitmap images by delegating to Codex CLI's hosted image generation and save them to local files.",
     promptGuidelines: [
       "Use generate_image when the user asks to create, generate, draw, render, or make a bitmap image file.",
       `When using generate_image, omit outputPath unless the user specified a path; default outputs are saved under ${DEFAULT_OUTPUT_DIR}/.`,
@@ -165,11 +193,20 @@ export default function (pi: ExtensionAPI) {
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const outputFormat = inferOutputFormat(params.outputPath, params.outputFormat);
-      const outputPath = withDefaultExtension(resolveOutputPath(ctx.cwd, params.outputPath, outputFormat), outputFormat);
-      const lastMessagePath = join(tmpdir(), `pi-codex-image-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`);
+      const outputPath = withDefaultExtension(
+        resolveOutputPath(ctx.cwd, params.outputPath, outputFormat),
+        outputFormat,
+      );
+      const lastMessagePath = join(
+        tmpdir(),
+        `pi-codex-image-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`,
+      );
       const timeout = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-      onUpdate?.({ content: [{ type: "text", text: "Generating image via Codex..." }] });
+      onUpdate?.({
+        content: [{ type: "text", text: "Generating image via Codex..." }],
+        details: {},
+      });
 
       await mkdir(dirname(outputPath), { recursive: true });
 
@@ -201,7 +238,9 @@ export default function (pi: ExtensionAPI) {
 
       const lastMessage = await readFile(lastMessagePath, "utf8").catch(() => "");
       if (result.code !== 0 || lastMessage.trim() === "IMAGE_TOOL_UNAVAILABLE") {
-        throw new Error(`Codex image generation failed.\n${codexFailureMessage(result, lastMessage)}`);
+        throw new Error(
+          `Codex image generation failed.\n${codexFailureMessage(result, lastMessage)}`,
+        );
       }
 
       const validation = await validateGeneratedImage(outputPath);

--- a/shared/stow/pi/.pi/agent/extensions/inline-skills.ts
+++ b/shared/stow/pi/.pi/agent/extensions/inline-skills.ts
@@ -1,4 +1,8 @@
-import { CustomEditor, type ExtensionAPI, type KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import {
+  CustomEditor,
+  type ExtensionAPI,
+  type KeybindingsManager,
+} from "@earendil-works/pi-coding-agent";
 import { readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -22,7 +26,10 @@ async function readSkillFile(sourcePath: string): Promise<string> {
   return readFile(skillPath, "utf8");
 }
 
-function findInlineSkillNames(text: string, commands: PiCommand[]): { names: string[]; missingSkills: string[] } {
+function findInlineSkillNames(
+  text: string,
+  commands: PiCommand[],
+): { names: string[]; missingSkills: string[] } {
   const names = new Set<string>();
   const missingSkills = new Set<string>();
 
@@ -52,7 +59,8 @@ function stripInlineSkillMarkers(text: string, commands: PiCommand[]): string {
 
 function findSkillCommand(commands: PiCommand[], name: string): PiCommand | undefined {
   return commands.find(
-    (command) => command.source === "skill" && (command.name === `skill:${name}` || command.name === name),
+    (command) =>
+      command.source === "skill" && (command.name === `skill:${name}` || command.name === name),
   );
 }
 
@@ -113,11 +121,16 @@ function getInlineSkillAutocompleteItems(commands: PiCommand[], prefix: string) 
     .sort((a, b) => a.value.localeCompare(b.value));
 }
 
-type AutocompleteTriggerableEditor = CustomEditor & { tryTriggerAutocomplete(): void };
+type EditorLike = { handleInput(data: string): void };
+
+function triggerAutocomplete(editor: object): void {
+  const trigger = Reflect.get(editor, "tryTriggerAutocomplete");
+  if (typeof trigger === "function") trigger.call(editor);
+}
 
 class InlineSkillEditor extends CustomEditor {
-  private baseEditor?: CustomEditor;
-  private keybindings: KeybindingsManager;
+  private baseEditor?: EditorLike;
+  private appKeybindings: KeybindingsManager;
   private onSubmitAttempt: () => void;
 
   constructor(
@@ -125,16 +138,16 @@ class InlineSkillEditor extends CustomEditor {
     theme: ConstructorParameters<typeof CustomEditor>[1],
     keybindings: KeybindingsManager,
     onSubmitAttempt: () => void,
-    baseEditor?: CustomEditor,
+    baseEditor?: EditorLike,
   ) {
     super(tui, theme, keybindings);
-    this.keybindings = keybindings;
+    this.appKeybindings = keybindings;
     this.onSubmitAttempt = onSubmitAttempt;
     this.baseEditor = baseEditor;
   }
 
   override handleInput(data: string): void {
-    const isSubmitting = this.keybindings.matches(data, "tui.input.submit");
+    const isSubmitting = this.appKeybindings.matches(data, "tui.input.submit");
     if (isSubmitting && this.getText().trim().length > 0) {
       this.emitStartupBannerDismissal();
     }
@@ -160,13 +173,16 @@ class InlineSkillEditor extends CustomEditor {
     const prefix = getInlineSkillAutocompletePrefix(beforeCursor);
     if (!prefix) return;
 
-    (this as AutocompleteTriggerableEditor).tryTriggerAutocomplete();
+    triggerAutocomplete(this);
   }
 }
 
-function formatLoadedSkills(skills: Array<{ name: string; path: string; content: string }>): string {
+function formatLoadedSkills(
+  skills: Array<{ name: string; path: string; content: string }>,
+): string {
   const sections = skills.map(
-    (skill) => `<skill name="${skill.name}" path="${skill.path}">\n${skill.content.trim()}\n</skill>`,
+    (skill) =>
+      `<skill name="${skill.name}" path="${skill.path}">\n${skill.content.trim()}\n</skill>`,
   );
 
   return [
@@ -189,7 +205,8 @@ export default function inlineSkills(pi: ExtensionAPI) {
         if (!prefix) return current.getSuggestions(lines, cursorLine, cursorCol, options);
 
         const items = getInlineSkillAutocompleteItems(pi.getCommands(), prefix);
-        if (items.length === 0) return current.getSuggestions(lines, cursorLine, cursorCol, options);
+        if (items.length === 0)
+          return current.getSuggestions(lines, cursorLine, cursorCol, options);
 
         return { prefix, items };
       },
@@ -240,7 +257,10 @@ export default function inlineSkills(pi: ExtensionAPI) {
     }
 
     if (missingSkills.length > 0) {
-      ctx.ui.notify(`Unknown inline skill(s): ${missingSkills.map((name) => `/skill:${name}`).join(", ")}`, "warning");
+      ctx.ui.notify(
+        `Unknown inline skill(s): ${missingSkills.map((name) => `/skill:${name}`).join(", ")}`,
+        "warning",
+      );
     }
 
     if (loadedSkills.length === 0) return { action: "continue" as const };

--- a/shared/stow/pi/.pi/agent/extensions/jest.config.mjs
+++ b/shared/stow/pi/.pi/agent/extensions/jest.config.mjs
@@ -1,0 +1,22 @@
+export default {
+  clearMocks: true,
+  extensionsToTreatAsEsm: [".ts"],
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/tests/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          parser: {
+            syntax: "typescript",
+          },
+          target: "es2022",
+        },
+        module: {
+          type: "es6",
+        },
+      },
+    ],
+  },
+};

--- a/shared/stow/pi/.pi/agent/extensions/lsp.ts
+++ b/shared/stow/pi/.pi/agent/extensions/lsp.ts
@@ -3,16 +3,16 @@ import { existsSync } from "node:fs";
 import { mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, resolve } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
   formatSize,
   truncateHead,
   withFileMutationQueue,
-} from "@mariozechner/pi-coding-agent";
-import { StringEnum } from "@mariozechner/pi-ai";
-import { Text } from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 type Language = "typescript" | "python" | "rust" | "ruby";
@@ -64,15 +64,23 @@ const NON_EMPTY_DIAGNOSTICS_QUIET_MS = 500;
 
 const LspDiagnosticsParams = Type.Object({
   path: Type.String({ description: "File path to diagnose. Relative paths resolve against cwd." }),
-  cwd: Type.Optional(Type.String({ description: "Working directory. Relative paths resolve against the current pi cwd." })),
-  root: Type.Optional(Type.String({ description: "Project root override. Relative paths resolve against cwd." })),
+  cwd: Type.Optional(
+    Type.String({
+      description: "Working directory. Relative paths resolve against the current pi cwd.",
+    }),
+  ),
+  root: Type.Optional(
+    Type.String({ description: "Project root override. Relative paths resolve against cwd." }),
+  ),
   language: Type.Optional(
     StringEnum(["auto", "typescript", "python", "rust", "ruby"] as const, {
       description: "Language server to use. Default: auto based on file extension.",
       default: "auto",
     }),
   ),
-  timeoutMs: Type.Optional(Type.Number({ description: `Timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.` })),
+  timeoutMs: Type.Optional(
+    Type.Number({ description: `Timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.` }),
+  ),
 });
 
 function pathToUri(path: string): string {
@@ -133,7 +141,11 @@ const ROOT_MARKERS: Record<Language, string[]> = {
   ruby: ["Gemfile", ".ruby-version", ".git"],
 };
 
-async function discoverRoot(filePath: string, language: Language, explicitRoot?: string): Promise<string> {
+async function discoverRoot(
+  filePath: string,
+  language: Language,
+  explicitRoot?: string,
+): Promise<string> {
   if (explicitRoot) return canonicalizeExistingPath(explicitRoot);
 
   let current = dirname(filePath);
@@ -163,7 +175,10 @@ function severityName(severity: number | undefined): string {
   }
 }
 
-function configurationForLanguage(language: Language, section: string | undefined): Record<string, unknown> {
+function configurationForLanguage(
+  language: Language,
+  section: string | undefined,
+): Record<string, unknown> {
   if (language === "python") {
     if (section === "python.analysis") {
       return {
@@ -202,7 +217,10 @@ async function cargoCheckDiagnostics(
 ): Promise<Diagnostic[]> {
   if (!existsSync(join(root, "Cargo.toml"))) return [];
 
-  const result = await pi.exec("cargo", ["check", "--message-format=json"], { cwd: root, timeout: timeoutMs });
+  const result = await pi.exec("cargo", ["check", "--message-format=json"], {
+    cwd: root,
+    timeout: timeoutMs,
+  });
   const diagnostics: Diagnostic[] = [];
 
   for (const line of result.stdout.split("\n")) {
@@ -234,11 +252,13 @@ async function cargoCheckDiagnostics(
 
     if (event.reason !== "compiler-message" || !event.message?.message) continue;
 
-    const primarySpan = event.message.spans?.find((span) => span.is_primary) ?? event.message.spans?.[0];
-    if (!primarySpan?.file_name) continue;
+    const primarySpan =
+      event.message.spans?.find((span) => span.is_primary) ?? event.message.spans?.[0];
+    const primaryFileName = primarySpan?.file_name;
+    if (!primaryFileName) continue;
 
-    const spanPath = await canonicalizeExistingPath(resolve(root, primarySpan.file_name)).catch(() =>
-      resolve(root, primarySpan.file_name),
+    const spanPath = await canonicalizeExistingPath(resolve(root, primaryFileName)).catch(() =>
+      resolve(root, primaryFileName),
     );
     if (spanPath !== filePath) continue;
 
@@ -288,7 +308,9 @@ async function truncateFormattedOutput(details: LspDetails): Promise<string> {
 
   const tempDir = await mkdtemp(join(tmpdir(), "pi-lsp-"));
   const outputPath = join(tempDir, "diagnostics.txt");
-  await withFileMutationQueue(outputPath, async () => writeFile(outputPath, details.formatted, "utf8"));
+  await withFileMutationQueue(outputPath, async () =>
+    writeFile(outputPath, details.formatted, "utf8"),
+  );
 
   details.truncated = true;
   details.fullOutputPath = outputPath;
@@ -333,7 +355,9 @@ class LspServer {
       this.pending.clear();
     });
     this.proc.on("close", (code) => {
-      const error = new Error(`${this.config.command} exited with code ${code}. ${this.stderr.trim()}`.trim());
+      const error = new Error(
+        `${this.config.command} exited with code ${code}. ${this.stderr.trim()}`.trim(),
+      );
       for (const pending of this.pending.values()) pending.reject(error);
       this.pending.clear();
     });
@@ -505,7 +529,7 @@ class LspServer {
   }
 
   private handleMessage(message: JsonRpcMessage): void {
-    if (message.id !== undefined && message.method === undefined) {
+    if (message.id !== undefined && message.id !== null && message.method === undefined) {
       const pending = this.pending.get(message.id);
       if (!pending) return;
 
@@ -541,7 +565,9 @@ class LspServer {
         const params = message.params as { items?: Array<{ section?: string }> } | undefined;
         this.respond(
           message.id,
-          (params?.items ?? []).map((item) => configurationForLanguage(this.language, item.section)),
+          (params?.items ?? []).map((item) =>
+            configurationForLanguage(this.language, item.section),
+          ),
         );
         return;
       }
@@ -590,7 +616,11 @@ export default function lsp(pi: ExtensionAPI) {
       const baseCwd = params.cwd ? resolve(ctx.cwd, params.cwd) : ctx.cwd;
       const filePath = await canonicalizeExistingPath(resolve(baseCwd, stripAt(params.path)));
       const language = detectLanguage(filePath, params.language ?? "auto");
-      const root = await discoverRoot(filePath, language, params.root ? resolve(baseCwd, params.root) : undefined);
+      const root = await discoverRoot(
+        filePath,
+        language,
+        params.root ? resolve(baseCwd, params.root) : undefined,
+      );
       const config = serverConfig(language);
       const content = await readFile(filePath, "utf8");
       const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -616,7 +646,9 @@ export default function lsp(pi: ExtensionAPI) {
     },
 
     renderCall(args, theme) {
-      let text = theme.fg("toolTitle", theme.bold("lsp_diagnostics ")) + theme.fg("accent", args.path ?? "...");
+      let text =
+        theme.fg("toolTitle", theme.bold("lsp_diagnostics ")) +
+        theme.fg("accent", args.path ?? "...");
       if (args.language && args.language !== "auto") text += theme.fg("muted", ` ${args.language}`);
       if (args.root) text += theme.fg("dim", ` root=${args.root}`);
       return new Text(text, 0, 0);
@@ -629,7 +661,12 @@ export default function lsp(pi: ExtensionAPI) {
       const errors = details.diagnostics.filter((diagnostic) => diagnostic.severity === 1).length;
       const warnings = details.diagnostics.filter((diagnostic) => diagnostic.severity === 2).length;
       const others = details.diagnostics.length - errors - warnings;
-      const icon = errors > 0 ? theme.fg("error", "✗") : warnings > 0 ? theme.fg("warning", "◐") : theme.fg("success", "✓");
+      const icon =
+        errors > 0
+          ? theme.fg("error", "✗")
+          : warnings > 0
+            ? theme.fg("warning", "◐")
+            : theme.fg("success", "✓");
       let text = `${icon} ${theme.fg("toolTitle", theme.bold("LSP"))} ${theme.fg("accent", details.language)} ${theme.fg(
         "muted",
         `${details.diagnostics.length} diagnostic${details.diagnostics.length === 1 ? "" : "s"}`,
@@ -637,7 +674,8 @@ export default function lsp(pi: ExtensionAPI) {
       if (details.diagnostics.length > 0) {
         text += theme.fg("dim", ` (${errors} errors, ${warnings} warnings, ${others} other)`);
       }
-      if (details.truncated && details.fullOutputPath) text += `\n${theme.fg("warning", `Truncated: ${details.fullOutputPath}`)}`;
+      if (details.truncated && details.fullOutputPath)
+        text += `\n${theme.fg("warning", `Truncated: ${details.fullOutputPath}`)}`;
 
       const content = result.content[0];
       if (expanded && content?.type === "text") {
@@ -647,7 +685,8 @@ export default function lsp(pi: ExtensionAPI) {
       } else if (content?.type === "text") {
         const lines = content.text.split("\n").slice(0, 8);
         text += `\n${theme.fg("toolOutput", lines.join("\n"))}`;
-        if (content.text.split("\n").length > 8) text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
+        if (content.text.split("\n").length > 8)
+          text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
       }
 
       return new Text(text, 0, 0);

--- a/shared/stow/pi/.pi/agent/extensions/mcp.ts
+++ b/shared/stow/pi/.pi/agent/extensions/mcp.ts
@@ -3,8 +3,8 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 type JsonRpcMessage = {
@@ -62,18 +62,28 @@ const PROTOCOL_VERSION = "2024-11-05";
 
 const ListToolsParams = Type.Object({
   server: Type.String({ description: "Configured MCP server name." }),
-  timeoutMs: Type.Optional(Type.Number({ description: `Timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.` })),
+  timeoutMs: Type.Optional(
+    Type.Number({ description: `Timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.` }),
+  ),
 });
 
 const CallToolParams = Type.Object({
   server: Type.String({ description: "Configured MCP server name." }),
   tool: Type.String({ description: "MCP tool name to call." }),
-  arguments: Type.Optional(Type.Record(Type.String(), Type.Unknown(), { description: "Arguments to pass to the MCP tool." })),
-  timeoutMs: Type.Optional(Type.Number({ description: `Timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.` })),
+  arguments: Type.Optional(
+    Type.Record(Type.String(), Type.Unknown(), {
+      description: "Arguments to pass to the MCP tool.",
+    }),
+  ),
+  timeoutMs: Type.Optional(
+    Type.Number({ description: `Timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.` }),
+  ),
 });
 
 const ResetServerParams = Type.Object({
-  server: Type.String({ description: 'Configured MCP server name, or "all" to reset every server.' }),
+  server: Type.String({
+    description: 'Configured MCP server name, or "all" to reset every server.',
+  }),
 });
 
 function expandPath(path: string): string {
@@ -88,9 +98,13 @@ function resolveValue(value: string): string {
   return process.env[envMatch[1] ?? ""] ?? "";
 }
 
-function resolveRecord(record: Record<string, string> | undefined): Record<string, string> | undefined {
+function resolveRecord(
+  record: Record<string, string> | undefined,
+): Record<string, string> | undefined {
   if (!record) return undefined;
-  return Object.fromEntries(Object.entries(record).map(([key, value]) => [key, resolveValue(value)]));
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, resolveValue(value)]),
+  );
 }
 
 async function loadConfig(cwd: string): Promise<{ config: McpConfig; paths: string[] }> {
@@ -102,7 +116,7 @@ async function loadConfig(cwd: string): Promise<{ config: McpConfig; paths: stri
     if (!existsSync(path)) continue;
     const raw = await readFile(path, "utf8");
     const parsed = JSON.parse(raw) as McpConfig;
-    merged.servers = { ...(merged.servers ?? {}), ...(parsed.servers ?? {}) };
+    merged.servers = { ...merged.servers, ...parsed.servers };
     loadedPaths.push(path);
   }
 
@@ -112,7 +126,10 @@ async function loadConfig(cwd: string): Promise<{ config: McpConfig; paths: stri
 function formatMcpContent(result: unknown): string {
   if (!result || typeof result !== "object") return JSON.stringify(result, null, 2);
 
-  const maybeContent = result as { content?: Array<{ type?: string; text?: string; [key: string]: unknown }>; isError?: boolean };
+  const maybeContent = result as {
+    content?: Array<{ type?: string; text?: string; [key: string]: unknown }>;
+    isError?: boolean;
+  };
   if (!Array.isArray(maybeContent.content)) return JSON.stringify(result, null, 2);
 
   return maybeContent.content
@@ -125,7 +142,9 @@ function formatMcpContent(result: unknown): string {
 
 function formatToolList(tools: McpTool[]): string {
   if (tools.length === 0) return "No tools returned by MCP server.";
-  return tools.map((tool) => `- ${tool.name}${tool.description ? ` — ${tool.description}` : ""}`).join("\n");
+  return tools
+    .map((tool) => `- ${tool.name}${tool.description ? ` — ${tool.description}` : ""}`)
+    .join("\n");
 }
 
 function parseCommandArgs(input: string): string[] {
@@ -181,20 +200,35 @@ function parseJsonObject(raw: string | undefined): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
-function clientStatusText(name: string, client: McpClient | undefined, failures: Map<string, string>): string {
+function clientStatusText(
+  name: string,
+  client: McpClient | undefined,
+  failures: Map<string, string>,
+): string {
   if (client) return client.state === "ready" ? "running" : client.state;
   const failure = failures.get(name);
   return failure ? `failed: ${failure}` : "lazy";
 }
 
-function formatServerList(config: McpConfig, clients: Map<string, McpClient>, failures: Map<string, string>, paths: string[]): string {
+function formatServerList(
+  config: McpConfig,
+  clients: Map<string, McpClient>,
+  failures: Map<string, string>,
+  paths: string[],
+): string {
   const servers = Object.entries(config.servers ?? {});
   const body =
     servers.length === 0
       ? "No MCP servers configured. Add ~/.pi/agent/mcp.json or .pi/mcp.json."
-      : servers.map(([name, server]) => `- ${name} (${server.type}) ${clientStatusText(name, clients.get(name), failures)}`).join("\n");
+      : servers
+          .map(
+            ([name, server]) =>
+              `- ${name} (${server.type}) ${clientStatusText(name, clients.get(name), failures)}`,
+          )
+          .join("\n");
 
-  const pathText = paths.length > 0 ? `\n\nConfig:\n${paths.map((path) => `- ${path}`).join("\n")}` : "";
+  const pathText =
+    paths.length > 0 ? `\n\nConfig:\n${paths.map((path) => `- ${path}`).join("\n")}` : "";
   return `${body}${pathText}`;
 }
 
@@ -247,7 +281,11 @@ class StdioMcpClient {
     this.proc.on("close", (code, signal) => {
       if (this.closing) return this.finishClose(undefined);
       const suffix = this.stderr.trim() ? ` ${this.stderr.trim().slice(-2_000)}` : "";
-      this.fail(new Error(`${config.command} exited with code ${code}${signal ? ` signal ${signal}` : ""}.${suffix}`));
+      this.fail(
+        new Error(
+          `${config.command} exited with code ${code}${signal ? ` signal ${signal}` : ""}.${suffix}`,
+        ),
+      );
     });
   }
 
@@ -304,7 +342,9 @@ class StdioMcpClient {
 
   private request(method: string, params: unknown, timeoutMs: number): Promise<unknown> {
     if (this.state === "failed" || this.state === "stopped") {
-      return Promise.reject(new Error(`${this.name} is ${this.state}${this.lastError ? `: ${this.lastError}` : ""}`));
+      return Promise.reject(
+        new Error(`${this.name} is ${this.state}${this.lastError ? `: ${this.lastError}` : ""}`),
+      );
     }
 
     const id = this.nextId++;
@@ -338,7 +378,11 @@ class StdioMcpClient {
   private onData(chunk: Buffer): void {
     this.buffer = Buffer.concat([this.buffer, chunk]);
     while (this.buffer.length > 0) {
-      if (this.buffer.toString("utf8", 0, Math.min(this.buffer.length, 32)).startsWith("Content-Length:")) {
+      if (
+        this.buffer
+          .toString("utf8", 0, Math.min(this.buffer.length, 32))
+          .startsWith("Content-Length:")
+      ) {
         if (!this.parseContentLengthFrame()) return;
         continue;
       }
@@ -372,7 +416,7 @@ class StdioMcpClient {
   }
 
   private handleMessage(message: JsonRpcMessage): void {
-    if (message.id !== undefined && message.method === undefined) {
+    if (message.id !== undefined && message.id !== null && message.method === undefined) {
       const pending = this.pending.get(message.id);
       if (!pending) return;
       clearTimeout(pending.timer);
@@ -382,7 +426,7 @@ class StdioMcpClient {
       return;
     }
 
-    if (message.id !== undefined && message.method) {
+    if (message.id !== undefined && message.id !== null && message.method) {
       this.send({ jsonrpc: "2.0", id: message.id, result: message.method === "ping" ? {} : null });
     }
   }
@@ -406,12 +450,13 @@ class StdioMcpClient {
 
   private killProcess(): void {
     if (this.proc.killed) return;
-    if (process.platform !== "win32" && this.proc.pid) {
+    const pid = this.proc.pid;
+    if (process.platform !== "win32" && pid) {
       try {
-        process.kill(-this.proc.pid, "SIGTERM");
+        process.kill(-pid, "SIGTERM");
         setTimeout(() => {
           try {
-            process.kill(-this.proc.pid!, "SIGKILL");
+            process.kill(-pid, "SIGKILL");
           } catch {
             // Process group is already gone.
           }
@@ -514,8 +559,10 @@ class HttpMcpClient {
 
       const sessionId = response.headers.get("mcp-session-id");
       if (sessionId) this.sessionId = sessionId;
-      if (!response.ok) throw new Error(`${this.name} HTTP ${response.status}: ${await response.text()}`);
-      if (response.status === 202 || response.status === 204) return { jsonrpc: "2.0", result: null };
+      if (!response.ok)
+        throw new Error(`${this.name} HTTP ${response.status}: ${await response.text()}`);
+      if (response.status === 202 || response.status === 204)
+        return { jsonrpc: "2.0", result: null };
 
       const contentType = response.headers.get("content-type") ?? "";
       const text = await response.text();
@@ -546,7 +593,8 @@ export default function mcp(pi: ExtensionAPI) {
   async function getServerConfig(ctx: { cwd: string }, server: string): Promise<ServerConfig> {
     const { config } = await loadConfig(ctx.cwd);
     const serverConfig = config.servers?.[server];
-    if (!serverConfig) throw new Error(`Unknown MCP server "${server}". Use mcp_list_servers first.`);
+    if (!serverConfig)
+      throw new Error(`Unknown MCP server "${server}". Use mcp_list_servers first.`);
     return serverConfig;
   }
 
@@ -562,7 +610,10 @@ export default function mcp(pi: ExtensionAPI) {
       if (clients.get(server) === client) clients.delete(server);
       if (message) failures.set(server, message);
     };
-    client = config.type === "stdio" ? new StdioMcpClient(server, config, ctx.cwd, onClose) : new HttpMcpClient(server, config, onClose);
+    client =
+      config.type === "stdio"
+        ? new StdioMcpClient(server, config, ctx.cwd, onClose)
+        : new HttpMcpClient(server, config, onClose);
     clients.set(server, client);
     return client;
   }
@@ -619,7 +670,12 @@ export default function mcp(pi: ExtensionAPI) {
           const config = await getServerConfig(ctx, server);
           const client = await getClient(ctx, server);
           const tools = await client.listTools(timeoutMs);
-          showCommandResult(formatToolList(tools), { server, type: config.type, running: true, tools });
+          showCommandResult(formatToolList(tools), {
+            server,
+            type: config.type,
+            running: true,
+            tools,
+          });
           return;
         }
 
@@ -632,7 +688,13 @@ export default function mcp(pi: ExtensionAPI) {
           const config = await getServerConfig(ctx, server);
           const client = await getClient(ctx, server);
           const result = await client.callTool(tool, jsonArgs, timeoutMs);
-          showCommandResult(formatMcpContent(result), { server, type: config.type, running: true, tool, result });
+          showCommandResult(formatMcpContent(result), {
+            server,
+            type: config.type,
+            running: true,
+            tool,
+            result,
+          });
           return;
         }
 
@@ -642,13 +704,19 @@ export default function mcp(pi: ExtensionAPI) {
           if (server === "all") {
             const count = clients.size;
             const failureCount = failures.size;
-            for (const name of [...clients.keys()]) shutdownClient(name);
+            for (const name of clients.keys()) shutdownClient(name);
             failures.clear();
-            showCommandResult(`Reset ${count} MCP client${count === 1 ? "" : "s"} and cleared ${failureCount} failure${failureCount === 1 ? "" : "s"}.`);
+            showCommandResult(
+              `Reset ${count} MCP client${count === 1 ? "" : "s"} and cleared ${failureCount} failure${failureCount === 1 ? "" : "s"}.`,
+            );
             return;
           }
           const stopped = shutdownClient(server);
-          showCommandResult(stopped ? `Reset MCP server ${server}.` : `MCP server ${server} was not running; cleared cached state.`);
+          showCommandResult(
+            stopped
+              ? `Reset MCP server ${server}.`
+              : `MCP server ${server} was not running; cleared cached state.`,
+          );
           return;
         }
 
@@ -659,7 +727,12 @@ export default function mcp(pi: ExtensionAPI) {
           const config = await getServerConfig(ctx, server);
           const client = await getClient(ctx, server);
           const tools = await client.listTools(timeoutMs);
-          showCommandResult(`Restarted ${server}.\n\n${formatToolList(tools)}`, { server, type: config.type, running: true, tools });
+          showCommandResult(`Restarted ${server}.\n\n${formatToolList(tools)}`, {
+            server,
+            type: config.type,
+            running: true,
+            tools,
+          });
           return;
         }
 
@@ -684,7 +757,10 @@ export default function mcp(pi: ExtensionAPI) {
         servers.length === 0
           ? "No MCP servers configured. Add ~/.pi/agent/mcp.json or .pi/mcp.json."
           : servers
-              .map(([name, server]) => `- ${name} (${server.type}) ${clientStatusText(name, clients.get(name), failures)}`)
+              .map(
+                ([name, server]) =>
+                  `- ${name} (${server.type}) ${clientStatusText(name, clients.get(name), failures)}`,
+              )
               .join("\n");
       return {
         content: [{ type: "text", text }],
@@ -718,36 +794,59 @@ export default function mcp(pi: ExtensionAPI) {
       const tools = await client.listTools(timeoutMs);
       return {
         content: [{ type: "text", text: formatToolList(tools) }],
-        details: { server: params.server, type: config.type, running: true, tools } satisfies McpDetails,
+        details: {
+          server: params.server,
+          type: config.type,
+          running: true,
+          tools,
+        } satisfies McpDetails,
       };
     },
     renderCall(args, theme) {
-      return new Text(theme.fg("toolTitle", theme.bold("mcp_list_tools ")) + theme.fg("accent", args.server ?? "..."), 0, 0);
+      return new Text(
+        theme.fg("toolTitle", theme.bold("mcp_list_tools ")) +
+          theme.fg("accent", args.server ?? "..."),
+        0,
+        0,
+      );
     },
   });
 
   pi.registerTool({
     name: "mcp_reset_server",
     label: "MCP Reset",
-    description: "Reset one MCP server client, or all clients, clearing cached failure/running state without starting servers.",
+    description:
+      "Reset one MCP server client, or all clients, clearing cached failure/running state without starting servers.",
     promptSnippet: "Reset a stuck MCP server client and clear cached failure state.",
     parameters: ResetServerParams,
     async execute(_id, params) {
       if (params.server === "all") {
         const count = clients.size;
         const failureCount = failures.size;
-        for (const name of [...clients.keys()]) shutdownClient(name);
+        for (const name of clients.keys()) shutdownClient(name);
         failures.clear();
         return {
-          content: [{ type: "text", text: `Reset ${count} MCP client${count === 1 ? "" : "s"} and cleared ${failureCount} failure${failureCount === 1 ? "" : "s"}.` }],
+          content: [
+            {
+              type: "text",
+              text: `Reset ${count} MCP client${count === 1 ? "" : "s"} and cleared ${failureCount} failure${failureCount === 1 ? "" : "s"}.`,
+            },
+          ],
           details: { server: params.server, reset: count, clearedFailures: failureCount },
         };
       }
 
       const stopped = shutdownClient(params.server);
       return {
-        content: [{ type: "text", text: stopped ? `Reset MCP server ${params.server}.` : `MCP server ${params.server} was not running; cleared cached state.` }],
-        details: { server: params.server, reset: stopped ? 1 : 0 },
+        content: [
+          {
+            type: "text",
+            text: stopped
+              ? `Reset MCP server ${params.server}.`
+              : `MCP server ${params.server} was not running; cleared cached state.`,
+          },
+        ],
+        details: { server: params.server, reset: stopped ? 1 : 0, clearedFailures: 0 },
       };
     },
   });
@@ -765,11 +864,19 @@ export default function mcp(pi: ExtensionAPI) {
       const result = await client.callTool(params.tool, params.arguments ?? {}, timeoutMs);
       return {
         content: [{ type: "text", text: formatMcpContent(result) }],
-        details: { server: params.server, type: config.type, running: true, tool: params.tool, result } satisfies McpDetails,
+        details: {
+          server: params.server,
+          type: config.type,
+          running: true,
+          tool: params.tool,
+          result,
+        } satisfies McpDetails,
       };
     },
     renderCall(args, theme) {
-      let text = theme.fg("toolTitle", theme.bold("mcp_call_tool ")) + theme.fg("accent", args.server ?? "...");
+      let text =
+        theme.fg("toolTitle", theme.bold("mcp_call_tool ")) +
+        theme.fg("accent", args.server ?? "...");
       text += theme.fg("muted", ` ${args.tool ?? "..."}`);
       return new Text(text, 0, 0);
     },
@@ -777,7 +884,8 @@ export default function mcp(pi: ExtensionAPI) {
       const details = result.details as McpDetails | undefined;
       const content = result.content[0];
       let text = theme.fg("success", "✓ ") + theme.fg("toolTitle", "MCP");
-      if (details) text += theme.fg("muted", ` ${details.server}${details.tool ? `.${details.tool}` : ""}`);
+      if (details)
+        text += theme.fg("muted", ` ${details.server}${details.tool ? `.${details.tool}` : ""}`);
       if (content?.type === "text") {
         const output = expanded ? content.text : content.text.split("\n").slice(0, 12).join("\n");
         text += `\n${theme.fg("toolOutput", output)}`;

--- a/shared/stow/pi/.pi/agent/extensions/package.json
+++ b/shared/stow/pi/.pi/agent/extensions/package.json
@@ -3,9 +3,33 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "validate": "node scripts/validate.mjs"
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
+    "lint": "oxlint . --tsconfig tsconfig.json --deny-warnings",
+    "test": "jest --passWithNoTests",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "validate": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test && node scripts/validate.mjs"
   },
   "devDependencies": {
-    "esbuild": "^0.25.5"
+    "@earendil-works/pi-ai": "0.75.4",
+    "@earendil-works/pi-coding-agent": "0.75.4",
+    "@earendil-works/pi-tui": "0.75.4",
+    "@swc/core": "^1.15.33",
+    "@swc/jest": "^0.2.39",
+    "@total-typescript/shoehorn": "^0.1.2",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^25.9.1",
+    "@typescript/native-preview": "7.0.0-dev.20260522.1",
+    "esbuild": "^0.28.0",
+    "jest": "^30.4.2",
+    "oxfmt": "^0.51.0",
+    "oxlint": "^1.66.0",
+    "typebox": "^1.1.38"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
   }
 }

--- a/shared/stow/pi/.pi/agent/extensions/pebble-orchestrator.ts
+++ b/shared/stow/pi/.pi/agent/extensions/pebble-orchestrator.ts
@@ -2,14 +2,26 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateTail, withFileMutationQueue } from "@mariozechner/pi-coding-agent";
-import { matchesKey, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateTail,
+  withFileMutationQueue,
+} from "@earendil-works/pi-coding-agent";
+import { matchesKey, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 type ExecResult = { stdout: string; stderr: string; code: number | null; killed?: boolean };
 type PebEnvelope<T> = { data: T; schema_version?: number };
-type LabelPolicy = { policy?: { groups?: Array<{ name?: string; labels?: string[]; cardinality?: string }>; strict?: boolean; version?: number } };
+type LabelPolicy = {
+  policy?: {
+    groups?: Array<{ name?: string; labels?: string[]; cardinality?: string }>;
+    strict?: boolean;
+    version?: number;
+  };
+};
 type PebIssue = {
   id: string;
   title: string;
@@ -69,7 +81,14 @@ type AgentRun = {
 type AgentProgressEvent = {
   issueId: string;
   role: AgentRole;
-  phase: "started" | "tool_start" | "tool_update" | "tool_end" | "assistant" | "stderr" | "finished";
+  phase:
+    | "started"
+    | "tool_start"
+    | "tool_update"
+    | "tool_end"
+    | "assistant"
+    | "stderr"
+    | "finished";
   text: string;
   elapsedMs: number;
 };
@@ -90,17 +109,35 @@ const KILL_GRACE_MS = 5_000;
 const COMMAND_TIMEOUT_MS = 120_000;
 
 const PebPlanParams = Type.Object({
-  repo: Type.Optional(Type.String({ description: "Pebbles workspace or path inside it. Defaults to current cwd." })),
-  concurrency: Type.Optional(Type.Number({ description: `Maximum parallel ready pebbles to select. Default: ${DEFAULT_CONCURRENCY}.` })),
-  state: Type.Optional(Type.String({ description: "Pickup label. Defaults to ready-for-agent when present, otherwise all open issues." })),
+  repo: Type.Optional(
+    Type.String({ description: "Pebbles workspace or path inside it. Defaults to current cwd." }),
+  ),
+  concurrency: Type.Optional(
+    Type.Number({
+      description: `Maximum parallel ready pebbles to select. Default: ${DEFAULT_CONCURRENCY}.`,
+    }),
+  ),
+  state: Type.Optional(
+    Type.String({
+      description:
+        "Pickup label. Defaults to ready-for-agent when present, otherwise all open issues.",
+    }),
+  ),
 });
 
 const PebSyncParams = Type.Object({
-  repo: Type.Optional(Type.String({ description: "Pebbles workspace or path inside it. Defaults to current cwd." })),
-  dryRun: Type.Optional(Type.Boolean({ description: "Report what would sync without mutating Pebbles." })),
+  repo: Type.Optional(
+    Type.String({ description: "Pebbles workspace or path inside it. Defaults to current cwd." }),
+  ),
+  dryRun: Type.Optional(
+    Type.Boolean({ description: "Report what would sync without mutating Pebbles." }),
+  ),
 });
 
-function parseArgs(input: string): { positionals: string[]; flags: Record<string, string | boolean> } {
+function parseArgs(input: string): {
+  positionals: string[];
+  flags: Record<string, string | boolean>;
+} {
   const tokens: string[] = [];
   let current = "";
   let quote: "'" | '"' | undefined;
@@ -192,11 +229,22 @@ function isClosed(issue: PebIssue): boolean {
 function getDependencyId(dep: unknown): string | undefined {
   if (!dep || typeof dep !== "object") return undefined;
   const record = dep as Record<string, unknown>;
-  for (const key of ["parent_id", "depends_on_id", "dependency_id", "target_id", "id", "issue_id"]) {
+  for (const key of [
+    "parent_id",
+    "depends_on_id",
+    "dependency_id",
+    "target_id",
+    "id",
+    "issue_id",
+  ]) {
     if (typeof record[key] === "string") return record[key] as string;
   }
   const issue = record.issue;
-  if (issue && typeof issue === "object" && typeof (issue as Record<string, unknown>).id === "string") {
+  if (
+    issue &&
+    typeof issue === "object" &&
+    typeof (issue as Record<string, unknown>).id === "string"
+  ) {
     return (issue as Record<string, string>).id;
   }
   return undefined;
@@ -217,10 +265,16 @@ function dependencyLooksOpen(dep: unknown): boolean {
 function deriveWorkflow(policy: LabelPolicy, requestedState?: string): Workflow {
   const groups = policy.policy?.groups ?? [];
   const labels = groups.flatMap((group) => group.labels ?? []);
-  const stateGroup = groups.find((group) => group.name === "state" || group.labels?.includes("ready-for-agent") || group.labels?.includes("in-review"));
+  const stateGroup = groups.find(
+    (group) =>
+      group.name === "state" ||
+      group.labels?.includes("ready-for-agent") ||
+      group.labels?.includes("in-review"),
+  );
   const stateLabels = stateGroup?.labels ?? labels;
   return {
-    readyLabel: requestedState || (stateLabels.includes("ready-for-agent") ? "ready-for-agent" : undefined),
+    readyLabel:
+      requestedState || (stateLabels.includes("ready-for-agent") ? "ready-for-agent" : undefined),
     reviewLabel: stateLabels.includes("in-review") ? "in-review" : undefined,
     stateLabels,
     strictLabels: policy.policy?.strict ?? false,
@@ -229,10 +283,37 @@ function deriveWorkflow(policy: LabelPolicy, requestedState?: string): Workflow 
 
 function deriveArea(issue: PebIssue): string {
   const labels = issue.labels ?? [];
-  const nonState = labels.find((label) => !["bug", "enhancement", "ready-for-agent", "ready-for-human", "in-review", "needs-triage", "needs-info", "wontfix"].includes(label));
+  const nonState = labels.find(
+    (label) =>
+      ![
+        "bug",
+        "enhancement",
+        "ready-for-agent",
+        "ready-for-human",
+        "in-review",
+        "needs-triage",
+        "needs-info",
+        "wontfix",
+      ].includes(label),
+  );
   if (nonState) return nonState;
   const text = `${issue.title} ${issue.description ?? ""}`.toLowerCase();
-  for (const candidate of ["auth", "ui", "api", "docs", "documentation", "hook", "dep", "dependency", "lsp", "mcp", "pi", "git", "pebble", "test"]) {
+  for (const candidate of [
+    "auth",
+    "ui",
+    "api",
+    "docs",
+    "documentation",
+    "hook",
+    "dep",
+    "dependency",
+    "lsp",
+    "mcp",
+    "pi",
+    "git",
+    "pebble",
+    "test",
+  ]) {
     if (text.includes(candidate)) return candidate;
   }
   return "general";
@@ -240,8 +321,14 @@ function deriveArea(issue: PebIssue): string {
 
 function deriveRisk(issue: PebIssue): "low" | "medium" | "high" {
   const text = `${issue.title}\n${issue.description ?? ""}`;
-  if ((issue.priority ?? 2) <= 0 || text.length > 4000 || /migration|delete|security|auth|payment|database/i.test(text)) return "high";
-  if ((issue.priority ?? 2) <= 1 || text.length > 1500 || /refactor|workflow|orchestr/i.test(text)) return "medium";
+  if (
+    (issue.priority ?? 2) <= 0 ||
+    text.length > 4000 ||
+    /migration|delete|security|auth|payment|database/i.test(text)
+  )
+    return "high";
+  if ((issue.priority ?? 2) <= 1 || text.length > 1500 || /refactor|workflow|orchestr/i.test(text))
+    return "medium";
   return "low";
 }
 
@@ -276,7 +363,8 @@ function formatPlan(plan: Plan): string {
   if (deferred.length > 0) {
     lines.push("", "Deferred / skipped:");
     for (const item of deferred) {
-      const reason = item.blockingReasons.length > 0 ? item.blockingReasons.join("; ") : "not in selected batch";
+      const reason =
+        item.blockingReasons.length > 0 ? item.blockingReasons.join("; ") : "not in selected batch";
       lines.push(`- ${item.issue.id} — ${item.issue.title} (${reason})`);
     }
   }
@@ -293,8 +381,14 @@ function formatRunResults(results: RunResult[]): string {
     lines.push(`${icon} ${id} — ${result.item.issue.title}`);
     lines.push(`  branch: ${result.item.branch}`);
     lines.push(`  worktree: ${result.worktreePath}`);
-    if (result.implementer) lines.push(`  implementer: exit ${result.implementer.exitCode}, ${(result.implementer.durationMs / 1000).toFixed(1)}s`);
-    if (result.reviewer) lines.push(`  reviewer: exit ${result.reviewer.exitCode}, ${(result.reviewer.durationMs / 1000).toFixed(1)}s${result.approved ? ", APPROVED" : ""}`);
+    if (result.implementer)
+      lines.push(
+        `  implementer: exit ${result.implementer.exitCode}, ${(result.implementer.durationMs / 1000).toFixed(1)}s`,
+      );
+    if (result.reviewer)
+      lines.push(
+        `  reviewer: exit ${result.reviewer.exitCode}, ${(result.reviewer.durationMs / 1000).toFixed(1)}s${result.approved ? ", APPROVED" : ""}`,
+      );
     if (result.pr?.url) lines.push(`  PR: ${result.pr.url}`);
     if (result.errors.length > 0) lines.push(`  errors: ${result.errors.join("; ")}`);
   }
@@ -305,23 +399,36 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
 }
 
-async function limitMap<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-  const results: R[] = new Array(items.length);
+async function limitMap<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = Array.from<R | undefined>({ length: items.length });
   let next = 0;
-  const workers = Array.from({ length: Math.max(1, Math.min(concurrency, items.length)) }, async () => {
-    while (next < items.length) {
-      const index = next;
-      next += 1;
-      results[index] = await fn(items[index] as T);
-    }
-  });
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(concurrency, items.length)) },
+    async () => {
+      while (next < items.length) {
+        const index = next;
+        next += 1;
+        results[index] = await fn(items[index] as T);
+      }
+    },
+  );
   await Promise.all(workers);
-  return results;
+  return results.map((result) => {
+    if (result === undefined) throw new Error("limitMap worker did not produce a result");
+    return result;
+  });
 }
 
 async function maybeTruncateRun(run: AgentRun): Promise<string> {
   const combined = run.finalOutput || run.stderr || "(no output)";
-  const truncation = truncateTail(combined, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
+  const truncation = truncateTail(combined, {
+    maxLines: DEFAULT_MAX_LINES,
+    maxBytes: DEFAULT_MAX_BYTES,
+  });
   if (!truncation.truncated) return truncation.content;
   const path = join(run.cwd, `.pi-${run.role}-${run.issueId}-output.txt`);
   await withFileMutationQueue(path, async () => writeFile(path, combined, "utf8"));
@@ -344,7 +451,17 @@ function getPiInvocation(args: string[]): { command: string; args: string[] } {
 }
 
 function buildAgentArgs(task: string, model: string, tools: string[]): string[] {
-  return ["--mode", "json", "--no-session", "--model", model, "--tools", tools.join(","), "-p", task];
+  return [
+    "--mode",
+    "json",
+    "--no-session",
+    "--model",
+    model,
+    "--tools",
+    tools.join(","),
+    "-p",
+    task,
+  ];
 }
 
 async function runPiAgent(params: {
@@ -370,13 +487,23 @@ async function runPiAgent(params: {
   };
   const invocation = getPiInvocation(buildAgentArgs(params.task, params.model, params.tools));
   const emit = (phase: AgentProgressEvent["phase"], text: string) => {
-    params.onEvent?.({ issueId: params.issueId, role: params.role, phase, text, elapsedMs: Date.now() - startedAt });
+    params.onEvent?.({
+      issueId: params.issueId,
+      role: params.role,
+      phase,
+      text,
+      elapsedMs: Date.now() - startedAt,
+    });
   };
 
   emit("started", `${params.role} started`);
 
   await new Promise<void>((resolvePromise) => {
-    const proc = spawn(invocation.command, invocation.args, { cwd: params.cwd, shell: false, stdio: ["ignore", "pipe", "pipe"] });
+    const proc = spawn(invocation.command, invocation.args, {
+      cwd: params.cwd,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     let stdoutBuffer = "";
     let settled = false;
     const finish = (code: number | null) => {
@@ -396,7 +523,10 @@ async function runPiAgent(params: {
         if (!settled) proc.kill("SIGKILL");
       }, KILL_GRACE_MS);
     };
-    const timeoutTimer = setTimeout(() => kill(`${params.role} timed out after ${params.timeoutMs}ms.`), params.timeoutMs);
+    const timeoutTimer = setTimeout(
+      () => kill(`${params.role} timed out after ${params.timeoutMs}ms.`),
+      params.timeoutMs,
+    );
     const processLine = (line: string) => {
       if (!line.trim()) return;
       let event: unknown;
@@ -410,12 +540,23 @@ async function runPiAgent(params: {
       const eventType = typeof candidate.type === "string" ? candidate.type : undefined;
       const toolName = typeof candidate.toolName === "string" ? candidate.toolName : undefined;
 
-      if (eventType === "tool_execution_start" && toolName) emit("tool_start", `${params.role}: ${toolName} started`);
-      if (eventType === "tool_execution_update" && toolName) emit("tool_update", `${params.role}: ${toolName} running`);
-      if (eventType === "tool_execution_end" && toolName) emit("tool_end", `${params.role}: ${toolName} finished`);
+      if (eventType === "tool_execution_start" && toolName)
+        emit("tool_start", `${params.role}: ${toolName} started`);
+      if (eventType === "tool_execution_update" && toolName)
+        emit("tool_update", `${params.role}: ${toolName} running`);
+      if (eventType === "tool_execution_end" && toolName)
+        emit("tool_end", `${params.role}: ${toolName} finished`);
 
-      if (candidate.type !== "message_end" || !candidate.message || typeof candidate.message !== "object") return;
-      const message = candidate.message as { role?: string; content?: Array<{ type?: string; text?: string }> };
+      if (
+        candidate.type !== "message_end" ||
+        !candidate.message ||
+        typeof candidate.message !== "object"
+      )
+        return;
+      const message = candidate.message as {
+        role?: string;
+        content?: Array<{ type?: string; text?: string }>;
+      };
       if (message.role !== "assistant") return;
       const text = (message.content ?? [])
         .filter((part) => part.type === "text" && typeof part.text === "string")
@@ -457,12 +598,22 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     return activeScrollController?.scrollBy(delta) ?? false;
   }
 
-  async function exec(command: string, args: string[], cwd: string, timeout = COMMAND_TIMEOUT_MS): Promise<ExecResult> {
+  async function exec(
+    command: string,
+    args: string[],
+    cwd: string,
+    timeout = COMMAND_TIMEOUT_MS,
+  ): Promise<ExecResult> {
     const result = (await pi.exec(command, args, { cwd, timeout })) as ExecResult;
     return result;
   }
 
-  async function checked(command: string, args: string[], cwd: string, timeout = COMMAND_TIMEOUT_MS): Promise<ExecResult> {
+  async function checked(
+    command: string,
+    args: string[],
+    cwd: string,
+    timeout = COMMAND_TIMEOUT_MS,
+  ): Promise<ExecResult> {
     const result = await exec(command, args, cwd, timeout);
     if (result.code !== 0) {
       const rendered = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
@@ -471,7 +622,10 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     return result;
   }
 
-  async function detect(repoArg: string | undefined, cwd: string): Promise<{ repo: string; gitRoot: string }> {
+  async function detect(
+    repoArg: string | undefined,
+    cwd: string,
+  ): Promise<{ repo: string; gitRoot: string }> {
     const start = repoArg ? resolve(cwd, repoArg) : cwd;
     const where = await checked("peb", ["where"], start);
     const repo = where.stdout.trim();
@@ -488,7 +642,12 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
 
   async function listOpenPrs(repo: string): Promise<OpenPr[]> {
     try {
-      const result = await exec("gh", ["pr", "list", "--state", "open", "--json", "number,headRefName,url"], repo, 30_000);
+      const result = await exec(
+        "gh",
+        ["pr", "list", "--state", "open", "--json", "number,headRefName,url"],
+        repo,
+        30_000,
+      );
       if (result.code !== 0) return [];
       return JSON.parse(result.stdout) as OpenPr[];
     } catch {
@@ -497,8 +656,15 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
   }
 
   async function listBranches(gitRoot: string): Promise<string[]> {
-    const result = await checked("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads"], gitRoot);
-    return result.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+    const result = await checked(
+      "git",
+      ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
+      gitRoot,
+    );
+    return result.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
   }
 
   async function currentBaseRef(gitRoot: string): Promise<string> {
@@ -517,22 +683,44 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
   }
 
   function branchMatchesIssue(branch: string, issueId: string): boolean {
-    return branch === issueId || branch.endsWith(`/${issueId}`) || branch.includes(`/${issueId}-`) || branch.includes(`/${issueId}_`);
+    return (
+      branch === issueId ||
+      branch.endsWith(`/${issueId}`) ||
+      branch.includes(`/${issueId}-`) ||
+      branch.includes(`/${issueId}_`)
+    );
   }
 
   function worktreeFor(gitRoot: string, issue: PebIssue): string {
-    return join(dirname(gitRoot), ".worktrees", `${basename(gitRoot)}-${issue.id}-${slugify(issue.title)}`);
+    return join(
+      dirname(gitRoot),
+      ".worktrees",
+      `${basename(gitRoot)}-${issue.id}-${slugify(issue.title)}`,
+    );
   }
 
-  async function createPlan(options: { repo?: string; cwd: string; concurrency?: number; state?: string }): Promise<Plan> {
+  async function createPlan(options: {
+    repo?: string;
+    cwd: string;
+    concurrency?: number;
+    state?: string;
+  }): Promise<Plan> {
     const { repo, gitRoot } = await detect(options.repo, options.cwd);
     const policy = await loadPolicy(repo);
     const workflow = deriveWorkflow(policy, options.state);
     const args = ["list", "--status", "open", "--json"];
     if (workflow.readyLabel) args.splice(1, 0, "--label", workflow.readyLabel);
     const issues = jsonData<PebIssue[]>((await checked("peb", args, repo)).stdout);
-    const [openPrs, branches, baseRef] = await Promise.all([listOpenPrs(gitRoot), listBranches(gitRoot), currentBaseRef(gitRoot)]);
-    const openPrBranches = new Set(openPrs.map((pr) => pr.headRefName).filter((value): value is string => typeof value === "string"));
+    const [openPrs, branches, baseRef] = await Promise.all([
+      listOpenPrs(gitRoot),
+      listBranches(gitRoot),
+      currentBaseRef(gitRoot),
+    ]);
+    const openPrBranches = new Set(
+      openPrs
+        .map((pr) => pr.headRefName)
+        .filter((value): value is string => typeof value === "string"),
+    );
     const branchSet = new Set(branches);
     const runId = `peb-${new Date().toISOString().replace(/[:.]/g, "-")}`;
 
@@ -544,11 +732,27 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
       const branch = branchFor(issue);
       const sandcastleBranch = `sandcastle/${issue.id}-${slugify(issue.title)}`;
       const blockingReasons: string[] = [];
-      const existingPr = openPrs.find((pr) => pr.headRefName === branch || pr.headRefName === sandcastleBranch || pr.headRefName?.includes(issue.id));
-      const existingBranch = [branch, sandcastleBranch, ...branches.filter((candidate) => branchMatchesIssue(candidate, issue.id))].find((candidate) => branchSet.has(candidate));
-      if (existingPr) blockingReasons.push(`open PR ${existingPr.number ?? existingPr.url ?? existingPr.headRefName}`);
-      else if (openPrBranches.has(branch) || openPrBranches.has(sandcastleBranch)) blockingReasons.push("open PR for orchestrator branch");
-      const openDeps = (issue.dependencies ?? []).filter(dependencyLooksOpen).map(getDependencyId).filter(Boolean);
+      const existingPr = openPrs.find(
+        (pr) =>
+          pr.headRefName === branch ||
+          pr.headRefName === sandcastleBranch ||
+          pr.headRefName?.includes(issue.id),
+      );
+      const existingBranch = [
+        branch,
+        sandcastleBranch,
+        ...branches.filter((candidate) => branchMatchesIssue(candidate, issue.id)),
+      ].find((candidate) => branchSet.has(candidate));
+      if (existingPr)
+        blockingReasons.push(
+          `open PR ${existingPr.number ?? existingPr.url ?? existingPr.headRefName}`,
+        );
+      else if (openPrBranches.has(branch) || openPrBranches.has(sandcastleBranch))
+        blockingReasons.push("open PR for orchestrator branch");
+      const openDeps = (issue.dependencies ?? [])
+        .filter(dependencyLooksOpen)
+        .map(getDependencyId)
+        .filter(Boolean);
       if (openDeps.length > 0) blockingReasons.push(`blocked by ${openDeps.join(", ")}`);
       const actualBranch = existingBranch ?? branch;
 
@@ -579,7 +783,17 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
       selected.push(item);
     }
 
-    return { repo, gitRoot, runId, workflow, concurrency: options.concurrency ?? DEFAULT_CONCURRENCY, baseRef, items, selected, openPrs };
+    return {
+      repo,
+      gitRoot,
+      runId,
+      workflow,
+      concurrency: options.concurrency ?? DEFAULT_CONCURRENCY,
+      baseRef,
+      items,
+      selected,
+      openPrs,
+    };
   }
 
   async function existingWorktrees(gitRoot: string): Promise<Map<string, string>> {
@@ -588,7 +802,8 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     let currentPath: string | undefined;
     for (const line of output.split("\n")) {
       if (line.startsWith("worktree ")) currentPath = line.slice("worktree ".length);
-      if (line.startsWith("branch refs/heads/") && currentPath) map.set(line.slice("branch refs/heads/".length), currentPath);
+      if (line.startsWith("branch refs/heads/") && currentPath)
+        map.set(line.slice("branch refs/heads/".length), currentPath);
     }
     return map;
   }
@@ -600,27 +815,52 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
 
   async function ensureWorktree(plan: Plan, item: PlanItem): Promise<string> {
     const worktrees = await existingWorktrees(plan.gitRoot);
-    const existing = worktrees.get(item.branch) ?? (item.existingBranch ? worktrees.get(item.existingBranch) : undefined);
+    const existing =
+      worktrees.get(item.branch) ??
+      (item.existingBranch ? worktrees.get(item.existingBranch) : undefined);
     if (existing) return existing;
     await mkdir(dirname(item.worktreePath), { recursive: true });
     if (await branchExists(plan.gitRoot, item.branch)) {
-      await checked("git", ["worktree", "add", item.worktreePath, item.branch], plan.gitRoot, 120_000);
+      await checked(
+        "git",
+        ["worktree", "add", item.worktreePath, item.branch],
+        plan.gitRoot,
+        120_000,
+      );
     } else {
-      await checked("git", ["worktree", "add", "-b", item.branch, item.worktreePath, plan.baseRef], plan.gitRoot, 120_000);
+      await checked(
+        "git",
+        ["worktree", "add", "-b", item.branch, item.worktreePath, plan.baseRef],
+        plan.gitRoot,
+        120_000,
+      );
     }
     return item.worktreePath;
   }
 
-  async function commentOnce(repo: string, issue: PebIssue, marker: string, body: string): Promise<void> {
+  async function commentOnce(
+    repo: string,
+    issue: PebIssue,
+    marker: string,
+    body: string,
+  ): Promise<void> {
     const latest = await showIssue(repo, issue.id);
     const exists = (latest.comments ?? []).some((comment) => comment.body?.includes(marker));
     if (exists) return;
     await checked("peb", ["comment", "add", issue.id, body], repo);
   }
 
-  async function dispatch(plan: Plan, model: string): Promise<Array<{ item: PlanItem; worktreePath: string }>> {
+  async function dispatch(
+    plan: Plan,
+    model: string,
+  ): Promise<Array<{ item: PlanItem; worktreePath: string }>> {
     const dispatched: Array<{ item: PlanItem; worktreePath: string }> = [];
-    pi.appendEntry("pebble-orchestrator-run", { runId: plan.runId, repo: plan.repo, model, selected: plan.selected.map((item) => item.issue.id) });
+    pi.appendEntry("pebble-orchestrator-run", {
+      runId: plan.runId,
+      repo: plan.repo,
+      model,
+      selected: plan.selected.map((item) => item.issue.id),
+    });
     for (const item of plan.selected) {
       const worktreePath = await ensureWorktree(plan, item);
       await checked("peb", ["update", item.issue.id, "--status", "in_progress"], plan.repo);
@@ -642,7 +882,14 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     return dispatched;
   }
 
-  function implementerPrompt(plan: Plan, item: PlanItem, worktreePath: string, model: string, attempt: number, reviewerFeedback?: string): string {
+  function implementerPrompt(
+    plan: Plan,
+    item: PlanItem,
+    worktreePath: string,
+    model: string,
+    attempt: number,
+    reviewerFeedback?: string,
+  ): string {
     const parts = [
       "You are a Pi implementer subagent working on exactly one Pebbles issue.",
       "Keep scope limited to this pebble. Do not work on unrelated issues. Do not spawn nested subagents.",
@@ -708,7 +955,11 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     ].join("\n");
   }
 
-  async function branchHasCommit(gitRoot: string, baseRef: string, branch: string): Promise<boolean> {
+  async function branchHasCommit(
+    gitRoot: string,
+    baseRef: string,
+    branch: string,
+  ): Promise<boolean> {
     const result = await exec("git", ["rev-list", "--count", `${baseRef}..${branch}`], gitRoot);
     return result.code === 0 && Number(result.stdout.trim()) > 0;
   }
@@ -736,7 +987,12 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
 
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       result.errors = [];
-      callbacks?.onItemStatus?.(item, "implementing", { worktreePath, attempt, maxAttempts, feedback: reviewerFeedback });
+      callbacks?.onItemStatus?.(item, "implementing", {
+        worktreePath,
+        attempt,
+        maxAttempts,
+        feedback: reviewerFeedback,
+      });
       result.implementer = await runPiAgent({
         issueId: item.issue.id,
         role: "implementer",
@@ -748,11 +1004,22 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
         onEvent: callbacks?.onAgentEvent,
       });
 
-      if (result.implementer.exitCode !== 0) result.errors.push(`implementer exited ${result.implementer.exitCode}`);
-      if (!(await branchHasCommit(plan.gitRoot, plan.baseRef, item.branch))) result.errors.push("branch has no commits over base");
+      if (result.implementer.exitCode !== 0)
+        result.errors.push(`implementer exited ${result.implementer.exitCode}`);
+      if (!(await branchHasCommit(plan.gitRoot, plan.baseRef, item.branch)))
+        result.errors.push("branch has no commits over base");
       if (result.errors.length > 0) {
         callbacks?.onItemStatus?.(item, "failed", { errors: result.errors, attempt, maxAttempts });
-        await checked("peb", ["comment", "add", item.issue.id, `pebble-orchestrator implementation did not complete in ${plan.runId}: ${result.errors.join("; ")}`], plan.repo).catch(() => undefined);
+        await checked(
+          "peb",
+          [
+            "comment",
+            "add",
+            item.issue.id,
+            `pebble-orchestrator implementation did not complete in ${plan.runId}: ${result.errors.join("; ")}`,
+          ],
+          plan.repo,
+        ).catch(() => undefined);
         return result;
       }
 
@@ -769,7 +1036,8 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
         onEvent: callbacks?.onAgentEvent,
       });
 
-      if (result.reviewer.exitCode !== 0) result.errors.push(`reviewer exited ${result.reviewer.exitCode}`);
+      if (result.reviewer.exitCode !== 0)
+        result.errors.push(`reviewer exited ${result.reviewer.exitCode}`);
       const verdict = reviewVerdict(result.reviewer.finalOutput);
       if (verdict === "approved" && result.errors.length === 0) {
         result.approved = true;
@@ -780,17 +1048,31 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
       result.approved = false;
       result.errors.push("reviewer requested changes");
       reviewerFeedback = result.reviewer.finalOutput;
-      callbacks?.onItemStatus?.(item, "changes_requested", { errors: result.errors, attempt, maxAttempts });
+      callbacks?.onItemStatus?.(item, "changes_requested", {
+        errors: result.errors,
+        attempt,
+        maxAttempts,
+      });
 
       if (attempt < maxAttempts) {
-        callbacks?.onItemStatus?.(item, "implementing", { worktreePath, attempt: attempt + 1, maxAttempts, feedback: reviewerFeedback });
+        callbacks?.onItemStatus?.(item, "implementing", {
+          worktreePath,
+          attempt: attempt + 1,
+          maxAttempts,
+          feedback: reviewerFeedback,
+        });
         continue;
       }
     }
 
     await checked(
       "peb",
-      ["comment", "add", item.issue.id, `pebble-orchestrator review did not approve in ${plan.runId} after ${maxAttempts} attempt${maxAttempts === 1 ? "" : "s"}: ${result.errors.join("; ")}\n\n${(result.reviewer?.finalOutput ?? "").slice(0, 4000)}`],
+      [
+        "comment",
+        "add",
+        item.issue.id,
+        `pebble-orchestrator review did not approve in ${plan.runId} after ${maxAttempts} attempt${maxAttempts === 1 ? "" : "s"}: ${result.errors.join("; ")}\n\n${(result.reviewer?.finalOutput ?? "").slice(0, 4000)}`,
+      ],
       plan.repo,
     ).catch(() => undefined);
     return result;
@@ -811,15 +1093,49 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
       await checked("git", ["push", "-u", "origin", branch], result.worktreePath, 120_000);
       const title = `${result.item.issue.id}: ${result.item.issue.title}`;
       const body = [`Closes: ${result.item.issue.id}`, "", `Pebbles run: ${plan.runId}`].join("\n");
-      const created = await checked("gh", ["pr", "create", "--base", plan.baseRef, "--head", branch, "--title", title, "--body", body], result.worktreePath, 120_000);
-      const createdUrl = created.stdout.trim().split("\n").find((line) => /^https?:\/\//.test(line.trim()))?.trim();
-      result.pr = (await findOpenPrForBranch(plan.gitRoot, branch)) ?? (createdUrl ? { headRefName: branch, url: createdUrl } : undefined);
+      const created = await checked(
+        "gh",
+        [
+          "pr",
+          "create",
+          "--base",
+          plan.baseRef,
+          "--head",
+          branch,
+          "--title",
+          title,
+          "--body",
+          body,
+        ],
+        result.worktreePath,
+        120_000,
+      );
+      const createdUrl = created.stdout
+        .trim()
+        .split("\n")
+        .find((line) => /^https?:\/\//.test(line.trim()))
+        ?.trim();
+      result.pr =
+        (await findOpenPrForBranch(plan.gitRoot, branch)) ??
+        (createdUrl ? { headRefName: branch, url: createdUrl } : undefined);
     }
     const prRef = result.pr?.url ?? (result.pr?.number ? String(result.pr.number) : undefined);
-    if (!prRef) throw new Error(`Could not determine PR reference for ${branch}; leaving labels unchanged.`);
+    if (!prRef)
+      throw new Error(`Could not determine PR reference for ${branch}; leaving labels unchanged.`);
     await checked("peb", ["closes", "add", result.item.issue.id, "--pr", prRef], plan.repo);
     if (plan.workflow.readyLabel && plan.workflow.reviewLabel) {
-      await checked("peb", ["update", result.item.issue.id, "--remove-label", plan.workflow.readyLabel, "--add-label", plan.workflow.reviewLabel], plan.repo);
+      await checked(
+        "peb",
+        [
+          "update",
+          result.item.issue.id,
+          "--remove-label",
+          plan.workflow.readyLabel,
+          "--add-label",
+          plan.workflow.reviewLabel,
+        ],
+        plan.repo,
+      );
     }
   }
 
@@ -841,32 +1157,60 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     const plan = await createPlan(options);
     options.onPlan?.(plan);
     if (plan.selected.length === 0) {
-      options.onProgress?.(`${formatPlan(plan)}\n\nNo pebbles selected; nothing to dispatch.`, plan);
+      options.onProgress?.(
+        `${formatPlan(plan)}\n\nNo pebbles selected; nothing to dispatch.`,
+        plan,
+      );
       return { plan, results: [] };
     }
 
-    options.onProgress?.(`${formatPlan(plan)}\n\nDispatching selected pebbles to worktrees...`, plan);
+    options.onProgress?.(
+      `${formatPlan(plan)}\n\nDispatching selected pebbles to worktrees...`,
+      plan,
+    );
     const dispatched = await dispatch(plan, options.model);
-    for (const { item, worktreePath } of dispatched) options.onItemStatus?.(item, "dispatched", { worktreePath });
+    for (const { item, worktreePath } of dispatched)
+      options.onItemStatus?.(item, "dispatched", { worktreePath });
 
     options.onProgress?.(
       `Dispatched ${dispatched.length} pebble${dispatched.length === 1 ? "" : "s"}. Running implementer and reviewer subagents now...`,
       { plan, dispatched },
     );
-    const results = await limitMap(dispatched, options.concurrency, async ({ item, worktreePath }) => {
-      if (options.uiDelayMs > 0) {
-        options.onItemStatus?.(item, "waiting", { worktreePath, delayMs: options.uiDelayMs });
-        options.onProgress?.(`UI test delay for ${item.issue.id}: waiting ${options.uiDelayMs}ms before implementer starts.`, { plan, item, worktreePath });
-        await sleep(options.uiDelayMs);
-      }
-      options.onProgress?.(`Working on ${item.issue.id}: implementer/reviewer subagents are running in ${worktreePath}`, { plan, item, worktreePath });
-      return runImplementation(plan, item, worktreePath, options.model, options.timeoutMs, options.maxAttempts, {
-        onItemStatus: options.onItemStatus,
-        onAgentEvent: options.onAgentEvent,
-      });
-    });
+    const results = await limitMap(
+      dispatched,
+      options.concurrency,
+      async ({ item, worktreePath }) => {
+        if (options.uiDelayMs > 0) {
+          options.onItemStatus?.(item, "waiting", { worktreePath, delayMs: options.uiDelayMs });
+          options.onProgress?.(
+            `UI test delay for ${item.issue.id}: waiting ${options.uiDelayMs}ms before implementer starts.`,
+            { plan, item, worktreePath },
+          );
+          await sleep(options.uiDelayMs);
+        }
+        options.onProgress?.(
+          `Working on ${item.issue.id}: implementer/reviewer subagents are running in ${worktreePath}`,
+          { plan, item, worktreePath },
+        );
+        return runImplementation(
+          plan,
+          item,
+          worktreePath,
+          options.model,
+          options.timeoutMs,
+          options.maxAttempts,
+          {
+            onItemStatus: options.onItemStatus,
+            onAgentEvent: options.onAgentEvent,
+          },
+        );
+      },
+    );
     if (options.createPrs) {
-      options.onProgress?.("Implementation/review finished. Opening PRs for approved branches...", { plan, results });
+      options.onProgress?.("Implementation/review finished. Opening PRs for approved branches...", {
+        plan,
+        results,
+      });
       for (const result of results) {
         try {
           if (result.approved) options.onItemStatus?.(result.item, "opening_pr", result);
@@ -876,7 +1220,16 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
           result.errors.push(`PR creation failed: ${formatError(error)}`);
           result.approved = false;
           options.onItemStatus?.(result.item, "pr_failed", { error: formatError(error) });
-          await checked("peb", ["comment", "add", result.item.issue.id, `pebble-orchestrator PR step failed in ${plan.runId}: ${formatError(error)}`], plan.repo).catch(() => undefined);
+          await checked(
+            "peb",
+            [
+              "comment",
+              "add",
+              result.item.issue.id,
+              `pebble-orchestrator PR step failed in ${plan.runId}: ${formatError(error)}`,
+            ],
+            plan.repo,
+          ).catch(() => undefined);
         }
       }
     }
@@ -902,8 +1255,29 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
   }
 
   function swimlaneCell(status: string, lane: "plan" | "implement" | "review" | "verdict"): string {
-    const planned = ["planned", "dispatched", "waiting", "implementing", "implemented", "reviewing", "approved", "opening_pr", "pr_opened", "changes_requested", "failed", "pr_failed"];
-    const implemented = ["implemented", "reviewing", "approved", "opening_pr", "pr_opened", "changes_requested", "pr_failed"];
+    const planned = [
+      "planned",
+      "dispatched",
+      "waiting",
+      "implementing",
+      "implemented",
+      "reviewing",
+      "approved",
+      "opening_pr",
+      "pr_opened",
+      "changes_requested",
+      "failed",
+      "pr_failed",
+    ];
+    const implemented = [
+      "implemented",
+      "reviewing",
+      "approved",
+      "opening_pr",
+      "pr_opened",
+      "changes_requested",
+      "pr_failed",
+    ];
     const reviewed = ["approved", "opening_pr", "pr_opened", "pr_failed"];
 
     if (lane === "plan") return planned.includes(status) ? "✓" : "○";
@@ -935,7 +1309,11 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     return `${compact}${" ".repeat(padding)}`;
   }
 
-  function semanticSwimlaneCell(status: string, lane: "plan" | "implement" | "review" | "verdict", theme: { fg: (name: string, text: string) => string }): string {
+  function semanticSwimlaneCell(
+    status: string,
+    lane: "plan" | "implement" | "review" | "verdict",
+    theme: { fg: (name: string, text: string) => string },
+  ): string {
     const cell = swimlaneCell(status, lane);
     if (lane === "plan") return theme.fg(cell === "✓" ? "success" : "muted", cell);
     if (lane === "implement") {
@@ -960,28 +1338,56 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
   }
 
   function isKittyReleaseEvent(data: string): boolean {
-    return /^\x1b\[\d+(?::\d*)?(?::\d+)?(?:;\d+)?(?::3)u$/.test(data);
+    // oxlint-disable-next-line no-control-regex -- matches the ESC byte in Kitty keyboard protocol release events.
+    return /^\u001B\[\d+(?::\d*)?(?::\d+)?(?:;\d+)?(?::3)u$/.test(data);
   }
 
   function isScrollUpInput(data: string): boolean {
     // matchesKey covers legacy VT (raw ctrl+k), Kitty CSI-u, and xterm modifyOtherKeys encodings.
     if (isKittyReleaseEvent(data)) return false;
-    return matchesKey(data, "ctrl+k") || matchesKey(data, "ctrl+shift+k") || data === "\x1b[1;3A" || data === "\x1b[3A" || data === "\x1bk";
+    return (
+      matchesKey(data, "ctrl+k") ||
+      matchesKey(data, "ctrl+shift+k") ||
+      data === "\x1b[1;3A" ||
+      data === "\x1b[3A" ||
+      data === "\x1bk"
+    );
   }
 
   function isScrollDownInput(data: string): boolean {
     // matchesKey covers legacy LF (raw ctrl+j), Kitty CSI-u, and xterm modifyOtherKeys encodings.
     if (isKittyReleaseEvent(data)) return false;
-    return matchesKey(data, "ctrl+j") || matchesKey(data, "ctrl+shift+j") || data === "\x1b[1;3B" || data === "\x1b[3B" || data === "\x1bj";
+    return (
+      matchesKey(data, "ctrl+j") ||
+      matchesKey(data, "ctrl+shift+j") ||
+      data === "\x1b[1;3B" ||
+      data === "\x1b[3B" ||
+      data === "\x1bj"
+    );
   }
 
   function makeUiProgress(ctx: {
     hasUI?: boolean;
     ui?: {
       notify?: (message: string, level?: "info" | "warning" | "error") => void;
-      onTerminalInput?: (handler: (data: string) => { consume?: boolean; data?: string } | undefined) => () => void;
+      onTerminalInput?: (
+        handler: (data: string) => { consume?: boolean; data?: string } | undefined,
+      ) => () => void;
       setStatus?: (key: string, value: string | undefined) => void;
-      setWidget?: (key: string, value: ((tui: unknown, theme: unknown) => { render: (width: number) => string[]; invalidate: () => void; dispose?: () => void }) | undefined, options?: { placement?: "aboveEditor" | "belowEditor" }) => void;
+      setWidget?: (
+        key: string,
+        value:
+          | ((
+              tui: unknown,
+              theme: unknown,
+            ) => {
+              render: (width: number) => string[];
+              invalidate: () => void;
+              dispose?: () => void;
+            })
+          | undefined,
+        options?: { placement?: "aboveEditor" | "belowEditor" },
+      ) => void;
     };
   }): {
     progress: (content: string, details?: unknown) => void;
@@ -1012,7 +1418,10 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     let requestWidgetRender: (() => void) | undefined;
     let unsubscribeTerminalInput: (() => void) | undefined;
 
-    const buildLines = (theme: { fg: (name: string, text: string) => string; bold: (text: string) => string }): string[] => {
+    const buildLines = (theme: {
+      fg: (name: string, text: string) => string;
+      bold: (text: string) => string;
+    }): string[] => {
       const lines = [theme.fg("muted", `Stage: ${compactText(stage, 90)}`)];
       if (plan) lines.push(theme.fg("muted", `Repo: ${compactText(plan.repo, 90)}`));
 
@@ -1028,7 +1437,8 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
             `${padCell(item.id, 12)}  ${padCell(semanticSwimlaneCell(item.status, "plan", theme), 6)} ${padCell(semanticSwimlaneCell(item.status, "implement", theme), 10)} ${padCell(semanticSwimlaneCell(item.status, "review", theme), 8)} ${padCell(semanticSwimlaneCell(item.status, "verdict", theme), 12)}`,
           );
           lines.push(`  ${theme.fg("muted", compactText(item.status + " · " + item.title, 92))}`);
-          if (item.role || item.latest) lines.push(`  ${compactText([item.role, item.latest].filter(Boolean).join(": "), 92)}`);
+          if (item.role || item.latest)
+            lines.push(`  ${compactText([item.role, item.latest].filter(Boolean).join(": "), 92)}`);
           lines.push(`  ${theme.fg("dim", compactText(item.branch, 92))}`);
         }
       }
@@ -1036,7 +1446,10 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
       const deferred = plan?.items.filter((item) => !plan?.selected.includes(item)) ?? [];
       if (deferred.length > 0) {
         lines.push("", theme.fg("muted", "Deferred"));
-        for (const item of deferred) lines.push(`○ ${item.issue.id} ${theme.fg("dim", compactText(item.blockingReasons.join("; ") || "not selected", 74))}`);
+        for (const item of deferred)
+          lines.push(
+            `○ ${item.issue.id} ${theme.fg("dim", compactText(item.blockingReasons.join("; ") || "not selected", 74))}`,
+          );
       }
 
       return lines;
@@ -1067,7 +1480,10 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
           const tui = tuiUnknown as {
             requestRender?: () => void;
           };
-          const theme = themeUnknown as { fg: (name: string, text: string) => string; bold: (text: string) => string };
+          const theme = themeUnknown as {
+            fg: (name: string, text: string) => string;
+            bold: (text: string) => string;
+          };
           let scroll = 0;
           const maxBodyLines = 16;
           const scrollBy = (delta: number): boolean => {
@@ -1107,10 +1523,19 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
                 const truncated = truncateToWidth(line, contentWidth, "…", true);
                 return ` ${truncated}${" ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)))} `;
               };
-              const lines = [border(`╭${"─".repeat(left)}`) + visibleTitle + border(`${"─".repeat(right)}╮`)];
+              const lines = [
+                border(`╭${"─".repeat(left)}`) + visibleTitle + border(`${"─".repeat(right)}╮`),
+              ];
               for (const line of visible) lines.push(border("│") + padLine(line) + border("│"));
-              while (lines.length < maxBodyLines + 1) lines.push(border("│") + padLine("") + border("│"));
-              const hint = maxScroll > 0 ? theme.fg("dim", `ctrl+j/k scroll; /peb-scroll up/down ${scroll + 1}/${maxScroll + 1}`) : theme.fg("dim", "all progress visible");
+              while (lines.length < maxBodyLines + 1)
+                lines.push(border("│") + padLine("") + border("│"));
+              const hint =
+                maxScroll > 0
+                  ? theme.fg(
+                      "dim",
+                      `ctrl+j/k scroll; /peb-scroll up/down ${scroll + 1}/${maxScroll + 1}`,
+                    )
+                  : theme.fg("dim", "all progress visible");
               lines.push(border("│") + padLine(hint) + border("│"));
               lines.push(border(`╰${"─".repeat(innerWidth)}╯`));
               return lines;
@@ -1159,13 +1584,16 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
           startedAt: Date.now(),
           updatedAt: Date.now(),
         };
-        const record = details && typeof details === "object" ? (details as Record<string, unknown>) : {};
+        const record =
+          details && typeof details === "object" ? (details as Record<string, unknown>) : {};
         const errors = Array.isArray(record.errors) ? record.errors.join("; ") : undefined;
         if (typeof record.worktreePath === "string") existing.worktree = record.worktreePath;
         existing.status = status;
-        if (status === "implementing" || status === "reviewing") existing.roleStartedAt = Date.now();
+        if (status === "implementing" || status === "reviewing")
+          existing.roleStartedAt = Date.now();
         existing.updatedAt = Date.now();
-        existing.latest = typeof record.error === "string" ? record.error : errors || existing.latest;
+        existing.latest =
+          typeof record.error === "string" ? record.error : errors || existing.latest;
         items.set(item.issue.id, existing);
         stage = `${item.issue.id}: ${status}`;
         render();
@@ -1174,11 +1602,16 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
         const item = items.get(event.issueId);
         if (!item) return;
         item.role = event.role;
-        if (!item.roleStartedAt || event.phase === "started") item.roleStartedAt = Date.now() - event.elapsedMs;
+        if (!item.roleStartedAt || event.phase === "started")
+          item.roleStartedAt = Date.now() - event.elapsedMs;
         item.agentElapsedMs = event.elapsedMs;
         item.latest = event.text;
         item.updatedAt = Date.now();
-        if (!["approved", "changes_requested", "failed", "pr_opened", "pr_failed"].includes(item.status)) {
+        if (
+          !["approved", "changes_requested", "failed", "pr_opened", "pr_failed"].includes(
+            item.status,
+          )
+        ) {
           item.status = event.role === "implementer" ? "implementing" : "reviewing";
         }
         stage = `${event.issueId}: ${compactText(event.text, 52)}`;
@@ -1197,7 +1630,19 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     };
   }
 
-  function parseRunOptions(args: string, cwd: string): { repo?: string; cwd: string; concurrency: number; state?: string; model: string; timeoutMs: number; maxAttempts: number; uiDelayMs: number } {
+  function parseRunOptions(
+    args: string,
+    cwd: string,
+  ): {
+    repo?: string;
+    cwd: string;
+    concurrency: number;
+    state?: string;
+    model: string;
+    timeoutMs: number;
+    maxAttempts: number;
+    uiDelayMs: number;
+  } {
     const parsed = parseArgs(args);
     return {
       repo: parsed.positionals[0],
@@ -1215,18 +1660,36 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
     description: "Scroll the live Pebbles orchestrator card: up, down, page-up, page-down",
     handler: async (args, ctx) => {
       const direction = args.trim().toLowerCase() || "down";
-      const delta = direction === "up" ? -1 : direction === "page-up" || direction === "pageup" ? -8 : direction === "page-down" || direction === "pagedown" ? 8 : 1;
+      const delta =
+        direction === "up"
+          ? -1
+          : direction === "page-up" || direction === "pageup"
+            ? -8
+            : direction === "page-down" || direction === "pagedown"
+              ? 8
+              : 1;
       const scrolled = scrollActiveWidget(delta);
-      if (ctx.hasUI) ctx.ui.notify(scrolled ? `Pebble card scrolled ${direction}` : "No active Pebbles card to scroll, or no more overflow.", scrolled ? "info" : "warning");
+      if (ctx.hasUI)
+        ctx.ui.notify(
+          scrolled
+            ? `Pebble card scrolled ${direction}`
+            : "No active Pebbles card to scroll, or no more overflow.",
+          scrolled ? "info" : "warning",
+        );
     },
   });
 
-  const registerScrollShortcut = (key: string, delta: number, direction: "up" | "down") => {
+  const registerScrollShortcut = (
+    key: Parameters<ExtensionAPI["registerShortcut"]>[0],
+    delta: number,
+    direction: "up" | "down",
+  ) => {
     pi.registerShortcut(key, {
       description: `Scroll Pebbles orchestrator card ${direction}`,
       handler: async (ctx) => {
         const scrolled = scrollActiveWidget(delta);
-        if (!scrolled && ctx.hasUI) ctx.ui.notify(`No active Pebbles card to scroll ${direction}.`, "warning");
+        if (!scrolled && ctx.hasUI)
+          ctx.ui.notify(`No active Pebbles card to scroll ${direction}.`, "warning");
       },
     });
   };
@@ -1253,7 +1716,10 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
       const uiProgress = makeUiProgress(ctx);
       try {
         const options = parseRunOptions(args, ctx.cwd);
-        uiProgress.progress(`Starting /peb-run-ready for ${options.repo ?? ctx.cwd}. This may take several minutes while subagents work...`, options);
+        uiProgress.progress(
+          `Starting /peb-run-ready for ${options.repo ?? ctx.cwd}. This may take several minutes while subagents work...`,
+          options,
+        );
         if (ctx.hasUI) ctx.ui.notify("Pebble orchestrator started", "info");
         const { plan, results } = await runReady({
           ...options,
@@ -1278,7 +1744,10 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
       const uiProgress = makeUiProgress(ctx);
       try {
         const options = parseRunOptions(args, ctx.cwd);
-        uiProgress.progress(`Starting /peb-burn-down for ${options.repo ?? ctx.cwd}. This may take several minutes while subagents work...`, options);
+        uiProgress.progress(
+          `Starting /peb-burn-down for ${options.repo ?? ctx.cwd}. This may take several minutes while subagents work...`,
+          options,
+        );
         if (ctx.hasUI) ctx.ui.notify("Pebble orchestrator started", "info");
         const { plan, results } = await runReady({
           ...options,
@@ -1316,35 +1785,58 @@ export default function pebbleOrchestrator(pi: ExtensionAPI) {
   pi.registerTool({
     name: "peb_plan",
     label: "Pebble Plan",
-    description: "Inspect a Pebbles workspace and produce a ready/unblocked execution plan. Does not mutate Pebbles or git.",
+    description:
+      "Inspect a Pebbles workspace and produce a ready/unblocked execution plan. Does not mutate Pebbles or git.",
     promptSnippet: "Plan ready Pebbles work without mutating the workspace.",
-    promptGuidelines: ["Use peb_plan when the user asks what Pebbles work is ready or wants an execution plan."],
+    promptGuidelines: [
+      "Use peb_plan when the user asks what Pebbles work is ready or wants an execution plan.",
+    ],
     parameters: PebPlanParams,
     async execute(_id, params, _signal, _onUpdate, ctx) {
-      const plan = await createPlan({ repo: params.repo, cwd: ctx.cwd, concurrency: params.concurrency ?? DEFAULT_CONCURRENCY, state: params.state });
+      const plan = await createPlan({
+        repo: params.repo,
+        cwd: ctx.cwd,
+        concurrency: params.concurrency ?? DEFAULT_CONCURRENCY,
+        state: params.state,
+      });
       return { content: [{ type: "text", text: formatPlan(plan) }], details: plan };
     },
     renderCall(args, theme) {
-      return new Text(theme.fg("toolTitle", theme.bold("peb_plan ")) + theme.fg("accent", args.repo ?? "cwd"), 0, 0);
+      return new Text(
+        theme.fg("toolTitle", theme.bold("peb_plan ")) + theme.fg("accent", args.repo ?? "cwd"),
+        0,
+        0,
+      );
     },
   });
 
   pi.registerTool({
     name: "peb_sync_github",
     label: "Pebble Sync",
-    description: "Run peb sync github for a Pebbles workspace. Finalizes pending PR close declarations after merge.",
+    description:
+      "Run peb sync github for a Pebbles workspace. Finalizes pending PR close declarations after merge.",
     promptSnippet: "Sync Pebbles PR close declarations from GitHub after PRs merge.",
-    promptGuidelines: ["Use peb_sync_github only when the user asks to sync completed Pebbles PR closures."],
+    promptGuidelines: [
+      "Use peb_sync_github only when the user asks to sync completed Pebbles PR closures.",
+    ],
     parameters: PebSyncParams,
     async execute(_id, params, _signal, _onUpdate, ctx) {
       const { repo } = await detect(params.repo, ctx.cwd);
       const args = ["sync", "github"];
       if (params.dryRun) args.push("--dry-run");
       const result = await checked("peb", args, repo, 120_000);
-      return { content: [{ type: "text", text: result.stdout.trim() || "peb sync github completed." }], details: { repo, dryRun: params.dryRun ?? false } };
+      return {
+        content: [{ type: "text", text: result.stdout.trim() || "peb sync github completed." }],
+        details: { repo, dryRun: params.dryRun ?? false },
+      };
     },
     renderCall(args, theme) {
-      return new Text(theme.fg("toolTitle", theme.bold("peb_sync_github ")) + theme.fg("accent", args.repo ?? "cwd"), 0, 0);
+      return new Text(
+        theme.fg("toolTitle", theme.bold("peb_sync_github ")) +
+          theme.fg("accent", args.repo ?? "cwd"),
+        0,
+        0,
+      );
     },
   });
 }

--- a/shared/stow/pi/.pi/agent/extensions/repo-picker.ts
+++ b/shared/stow/pi/.pi/agent/extensions/repo-picker.ts
@@ -16,30 +16,29 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
-import { CustomEditor, DynamicBorder } from "@earendil-works/pi-coding-agent";
-import { Container, Text, matchesKey, Key, truncateToWidth } from "@earendil-works/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { CustomEditor } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
 
 // ── Config ───────────────────────────────────────────────────────────
 
 /** Directories to scan one level deep */
 const SHALLOW_DIRS = [
-	"dev",
-	"projects",
-	"code",
-	"workspace",
-	"src",
-	"repos",
-	"github",
-	"gitlab",
-	"Documents",
+  "dev",
+  "projects",
+  "code",
+  "workspace",
+  "src",
+  "repos",
+  "github",
+  "gitlab",
+  "Documents",
 ];
 
 /** Directories to scan recursively (up to maxDepth levels) */
 const RECURSIVE_DIRS = [
-	{ path: "personal", maxDepth: 4 },
-	{ path: "work", maxDepth: 4 },
+  { path: "personal", maxDepth: 4 },
+  { path: "work", maxDepth: 4 },
 ];
 
 /** Specific repo paths to check directly */
@@ -50,120 +49,125 @@ const SCAN_HOME_IMMEDIATE = true;
 // ── Repo Discovery ───────────────────────────────────────────────────
 
 function isGitRepo(dir: string): boolean {
-	const gitPath = join(dir, ".git");
-	if (!existsSync(gitPath)) {
-		return false;
-	}
-	try {
-		const stat = statSync(gitPath);
-		if (stat.isDirectory()) {
-			return true;
-		}
-		if (stat.isFile()) {
-			// Worktree: only surface /main and /master checkouts inside bare repos
-			return dir.endsWith("/main") || dir.endsWith("/master");
-		}
-		return false;
-	} catch {
-		return false;
-	}
+  const gitPath = join(dir, ".git");
+  if (!existsSync(gitPath)) {
+    return false;
+  }
+  try {
+    const stat = statSync(gitPath);
+    if (stat.isDirectory()) {
+      return true;
+    }
+    if (stat.isFile()) {
+      // Worktree: only surface /main and /master checkouts inside bare repos
+      return dir.endsWith("/main") || dir.endsWith("/master");
+    }
+    return false;
+  } catch {
+    return false;
+  }
 }
 
 function findGitReposRecursive(dir: string, maxDepth: number, currentDepth = 0): string[] {
-	const repos: string[] = [];
-	if (currentDepth >= maxDepth) return repos;
+  const repos: string[] = [];
+  if (currentDepth >= maxDepth) return repos;
 
-	try {
-		const entries = readdirSync(dir, { withFileTypes: true });
-		for (const entry of entries) {
-			if (!entry.isDirectory()) continue;
-			if (entry.name.startsWith(".")) continue;
-			// Skip common non-repo directories
-			if (["node_modules", "vendor", "dist", "build", "target", "out", "coverage"].includes(entry.name)) continue;
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".")) continue;
+      // Skip common non-repo directories
+      if (
+        ["node_modules", "vendor", "dist", "build", "target", "out", "coverage"].includes(
+          entry.name,
+        )
+      )
+        continue;
 
-			const fullPath = join(dir, entry.name);
-			if (isGitRepo(fullPath)) {
-				repos.push(fullPath);
-			} else {
-				repos.push(...findGitReposRecursive(fullPath, maxDepth, currentDepth + 1));
-			}
-		}
-	} catch {
-		/* ignore permission errors */
-	}
+      const fullPath = join(dir, entry.name);
+      if (isGitRepo(fullPath)) {
+        repos.push(fullPath);
+      } else {
+        repos.push(...findGitReposRecursive(fullPath, maxDepth, currentDepth + 1));
+      }
+    }
+  } catch {
+    /* ignore permission errors */
+  }
 
-	return repos;
+  return repos;
 }
 
 function findGitRepos(): string[] {
-	const repos = new Set<string>();
-	const home = homedir();
+  const repos = new Set<string>();
+  const home = homedir();
 
-	// 1. Immediate subdirectories of home (e.g. ~/.dotfiles won't match because it starts with ".")
-	if (SCAN_HOME_IMMEDIATE) {
-		try {
-			const entries = readdirSync(home, { withFileTypes: true });
-			for (const entry of entries) {
-				if (entry.isDirectory() && !entry.name.startsWith(".")) {
-					const fullPath = join(home, entry.name);
-					if (isGitRepo(fullPath)) repos.add(fullPath);
-				}
-			}
-		} catch {
-			/* ignore permission errors */
-		}
-	}
+  // 1. Immediate subdirectories of home (e.g. ~/.dotfiles won't match because it starts with ".")
+  if (SCAN_HOME_IMMEDIATE) {
+    try {
+      const entries = readdirSync(home, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && !entry.name.startsWith(".")) {
+          const fullPath = join(home, entry.name);
+          if (isGitRepo(fullPath)) repos.add(fullPath);
+        }
+      }
+    } catch {
+      /* ignore permission errors */
+    }
+  }
 
-	// 2. Specific one-off repos (including hidden ones like ~/.dotfiles)
-	for (const specific of SPECIFIC_PATHS) {
-		const fullPath = join(home, specific);
-		if (existsSync(fullPath) && isGitRepo(fullPath)) {
-			repos.add(fullPath);
-		}
-	}
+  // 2. Specific one-off repos (including hidden ones like ~/.dotfiles)
+  for (const specific of SPECIFIC_PATHS) {
+    const fullPath = join(home, specific);
+    if (existsSync(fullPath) && isGitRepo(fullPath)) {
+      repos.add(fullPath);
+    }
+  }
 
-	// 3. Shallow scan: one level deep
-	for (const parent of SHALLOW_DIRS) {
-		const parentPath = join(home, parent);
-		if (!existsSync(parentPath)) continue;
+  // 3. Shallow scan: one level deep
+  for (const parent of SHALLOW_DIRS) {
+    const parentPath = join(home, parent);
+    if (!existsSync(parentPath)) continue;
 
-		try {
-			const entries = readdirSync(parentPath, { withFileTypes: true });
-			for (const entry of entries) {
-				if (entry.isDirectory() && !entry.name.startsWith(".")) {
-					const fullPath = join(parentPath, entry.name);
-					if (isGitRepo(fullPath)) repos.add(fullPath);
-				}
-			}
-		} catch {
-			/* ignore permission errors */
-		}
-	}
+    try {
+      const entries = readdirSync(parentPath, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && !entry.name.startsWith(".")) {
+          const fullPath = join(parentPath, entry.name);
+          if (isGitRepo(fullPath)) repos.add(fullPath);
+        }
+      }
+    } catch {
+      /* ignore permission errors */
+    }
+  }
 
-	// 4. Recursive scan: any depth up to maxDepth
-	for (const { path, maxDepth } of RECURSIVE_DIRS) {
-		const parentPath = join(home, path);
-		if (!existsSync(parentPath)) continue;
-		for (const repo of findGitReposRecursive(parentPath, maxDepth)) {
-			repos.add(repo);
-		}
-	}
+  // 4. Recursive scan: any depth up to maxDepth
+  for (const { path, maxDepth } of RECURSIVE_DIRS) {
+    const parentPath = join(home, path);
+    if (!existsSync(parentPath)) continue;
+    for (const repo of findGitReposRecursive(parentPath, maxDepth)) {
+      repos.add(repo);
+    }
+  }
 
-	return Array.from(repos).sort((a, b) => a.localeCompare(b));
+  return Array.from(repos).sort((a, b) => a.localeCompare(b));
 }
 
 let cachedRepos: string[] | null = null;
 
 function getRepos(): string[] {
-	if (!cachedRepos) {
-		cachedRepos = findGitRepos();
-	}
-	return cachedRepos;
+  if (!cachedRepos) {
+    cachedRepos = findGitRepos();
+  }
+  return cachedRepos;
 }
 
 function shortenHome(path: string): string {
-	const home = homedir();
-	return path.startsWith(home) ? path.replace(home, "~") : path;
+  const home = homedir();
+  return path.startsWith(home) ? path.replace(home, "~") : path;
 }
 
 // ── Autocomplete ─────────────────────────────────────────────────────
@@ -171,207 +175,212 @@ function shortenHome(path: string): string {
 const TOKEN_SEPARATORS = new Set([" ", "\t", "\n", "(", "[", "{"]);
 
 function getCurrentToken(text: string): { token: string; tokenStart: number } {
-	let tokenStart = text.length;
-	while (tokenStart > 0 && !TOKEN_SEPARATORS.has(text[tokenStart - 1] ?? "")) {
-		tokenStart -= 1;
-	}
-	return { token: text.slice(tokenStart), tokenStart };
+  let tokenStart = text.length;
+  while (tokenStart > 0 && !TOKEN_SEPARATORS.has(text[tokenStart - 1] ?? "")) {
+    tokenStart -= 1;
+  }
+  return { token: text.slice(tokenStart), tokenStart };
 }
 
 function getPathAutocompletePrefix(textBeforeCursor: string): string | undefined {
-	const { token } = getCurrentToken(textBeforeCursor);
+  const { token } = getCurrentToken(textBeforeCursor);
 
-	if (
-		token.startsWith("/path:") &&
-		(token.length === 6 || token[6] !== " ")
-	) {
-		return token;
-	}
+  if (token.startsWith("/path:") && (token.length === 6 || token[6] !== " ")) {
+    return token;
+  }
 
-	return undefined;
+  return undefined;
 }
 
 function getInlineSlashAutocompletePrefix(textBeforeCursor: string): string | undefined {
-	const { token, tokenStart } = getCurrentToken(textBeforeCursor);
+  const { token, tokenStart } = getCurrentToken(textBeforeCursor);
 
-	// Keep pi's built-in slash-command menu at the beginning of a prompt/line.
-	// This path is only for inline slash completions supplied by other provider
-	// wrappers, such as inline /skill:name completion.
-	if (textBeforeCursor.slice(0, tokenStart).trim().length === 0) return undefined;
+  // Keep pi's built-in slash-command menu at the beginning of a prompt/line.
+  // This path is only for inline slash completions supplied by other provider
+  // wrappers, such as inline /skill:name completion.
+  if (textBeforeCursor.slice(0, tokenStart).trim().length === 0) return undefined;
 
-	return token.startsWith("/") ? token : undefined;
+  return token.startsWith("/") ? token : undefined;
 }
 
 function getPathAutocompleteItems(repos: string[], prefix: string) {
-	const query = prefix.slice("/path:".length).toLowerCase();
+  const query = prefix.slice("/path:".length).toLowerCase();
 
-	return repos
-		.map((path) => ({
-			value: path,
-			label: shortenHome(path),
-		}))
-		.filter(
-			(item) => !query || fuzzyMatch(query, item.label) || fuzzyMatch(query, item.value),
-		)
-		.slice(0, 15)
-		.map((item) => ({
-			value: item.value,
-			label: item.label,
-			description: item.value,
-		}));
+  return repos
+    .map((path) => ({
+      value: path,
+      label: shortenHome(path),
+    }))
+    .filter((item) => !query || fuzzyMatch(query, item.label) || fuzzyMatch(query, item.value))
+    .slice(0, 15)
+    .map((item) => ({
+      value: item.value,
+      label: item.label,
+      description: item.value,
+    }));
 }
 
-type AutocompleteTriggerableEditor = CustomEditor & { tryTriggerAutocomplete(): void };
+type EditorLike = { handleInput(data: string): void };
+
+function triggerAutocomplete(editor: object): void {
+  const trigger = Reflect.get(editor, "tryTriggerAutocomplete");
+  if (typeof trigger === "function") trigger.call(editor);
+}
 
 class PathAutocompleteEditor extends CustomEditor {
-	private baseEditor?: CustomEditor;
+  private baseEditor?: EditorLike;
 
-	constructor(tui: unknown, theme: Theme, keybindings: unknown, baseEditor?: CustomEditor) {
-		super(tui, theme, keybindings);
-		this.baseEditor = baseEditor;
-	}
+  constructor(
+    tui: ConstructorParameters<typeof CustomEditor>[0],
+    theme: ConstructorParameters<typeof CustomEditor>[1],
+    keybindings: ConstructorParameters<typeof CustomEditor>[2],
+    baseEditor?: EditorLike,
+  ) {
+    super(tui, theme, keybindings);
+    this.baseEditor = baseEditor;
+  }
 
-	override handleInput(data: string): void {
-		this.baseEditor?.handleInput(data);
-		super.handleInput(data);
-		this.triggerPathAutocomplete();
-	}
+  override handleInput(data: string): void {
+    this.baseEditor?.handleInput(data);
+    super.handleInput(data);
+    this.triggerPathAutocomplete();
+  }
 
-	private triggerPathAutocomplete(): void {
-		if (this.isShowingAutocomplete()) return;
+  private triggerPathAutocomplete(): void {
+    if (this.isShowingAutocomplete()) return;
 
-		const cursor = this.getCursor();
-		const line = this.getLines()[cursor.line] ?? "";
-		const beforeCursor = line.slice(0, cursor.col);
-		const pathPrefix = getPathAutocompletePrefix(beforeCursor);
-		const inlineSlashPrefix = getInlineSlashAutocompletePrefix(beforeCursor);
-		if (!pathPrefix && !inlineSlashPrefix) return;
+    const cursor = this.getCursor();
+    const line = this.getLines()[cursor.line] ?? "";
+    const beforeCursor = line.slice(0, cursor.col);
+    const pathPrefix = getPathAutocompletePrefix(beforeCursor);
+    const inlineSlashPrefix = getInlineSlashAutocompletePrefix(beforeCursor);
+    if (!pathPrefix && !inlineSlashPrefix) return;
 
-		(this as AutocompleteTriggerableEditor).tryTriggerAutocomplete();
-	}
+    triggerAutocomplete(this);
+  }
 }
 
 // ── Fuzzy Match ──────────────────────────────────────────────────────
 
 /** Simple fuzzy match: every query char must appear in order in the text */
 function fuzzyMatch(query: string, text: string): boolean {
-	let qi = 0;
-	let ti = 0;
-	const q = query.toLowerCase();
-	const t = text.toLowerCase();
-	while (qi < q.length && ti < t.length) {
-		if (q[qi] === t[ti]) qi++;
-		ti++;
-	}
-	return qi === q.length;
+  let qi = 0;
+  let ti = 0;
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  while (qi < q.length && ti < t.length) {
+    if (q[qi] === t[ti]) qi++;
+    ti++;
+  }
+  return qi === q.length;
 }
 
 // ── Extension Entrypoint ─────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
-	/** Reference to the current session's editor (for insert-at-cursor) */
-	let currentEditor: CustomEditor | null = null;
+  /** Reference to the current session's editor (for insert-at-cursor) */
+  let currentEditor: CustomEditor | null = null;
 
-	// Install autocomplete provider + custom editor for auto-triggering
-	pi.on("session_start", (_event, ctx) => {
-		cachedRepos = null;
+  // Install autocomplete provider + custom editor for auto-triggering
+  pi.on("session_start", (_event, ctx) => {
+    cachedRepos = null;
 
-		ctx.ui.addAutocompleteProvider((current) => ({
-			async getSuggestions(lines, cursorLine, cursorCol, options) {
-				const line = lines[cursorLine] ?? "";
-				const beforeCursor = line.slice(0, cursorCol);
-				const prefix = getPathAutocompletePrefix(beforeCursor);
+    ctx.ui.addAutocompleteProvider((current) => ({
+      async getSuggestions(lines, cursorLine, cursorCol, options) {
+        const line = lines[cursorLine] ?? "";
+        const beforeCursor = line.slice(0, cursorCol);
+        const prefix = getPathAutocompletePrefix(beforeCursor);
 
-				if (!prefix) return current.getSuggestions(lines, cursorLine, cursorCol, options);
+        if (!prefix) return current.getSuggestions(lines, cursorLine, cursorCol, options);
 
-				const items = getPathAutocompleteItems(getRepos(), prefix);
-				if (items.length === 0)
-					return current.getSuggestions(lines, cursorLine, cursorCol, options);
+        const items = getPathAutocompleteItems(getRepos(), prefix);
+        if (items.length === 0)
+          return current.getSuggestions(lines, cursorLine, cursorCol, options);
 
-				return { prefix, items };
-			},
-			applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
-				// Only handle /path: completions — delegate commands, @refs, etc. to default
-				if (!prefix.startsWith("/path:")) {
-					return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
-				}
+        return { prefix, items };
+      },
+      applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+        // Only handle /path: completions — delegate commands, @refs, etc. to default
+        if (!prefix.startsWith("/path:")) {
+          return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+        }
 
-				const line = lines[cursorLine] ?? "";
-				const prefixStart = cursorCol - prefix.length;
-				if (prefixStart >= 0 && line.slice(prefixStart, cursorCol) === prefix) {
-					const before = line.slice(0, prefixStart);
-					const after = line.slice(cursorCol);
-					const newLine = before + item.value + after;
-					const newLines = [...lines];
-					newLines[cursorLine] = newLine;
-					return {
-						lines: newLines,
-						cursorLine,
-						cursorCol: prefixStart + item.value.length,
-					};
-				}
-				return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
-			},
-			shouldTriggerFileCompletion(_lines, _cursorLine, _cursorCol) {
-				return false;
-			},
-		}));
+        const line = lines[cursorLine] ?? "";
+        const prefixStart = cursorCol - prefix.length;
+        if (prefixStart >= 0 && line.slice(prefixStart, cursorCol) === prefix) {
+          const before = line.slice(0, prefixStart);
+          const after = line.slice(cursorCol);
+          const newLine = before + item.value + after;
+          const newLines = [...lines];
+          newLines[cursorLine] = newLine;
+          return {
+            lines: newLines,
+            cursorLine,
+            cursorCol: prefixStart + item.value.length,
+          };
+        }
+        return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+      },
+      shouldTriggerFileCompletion(_lines, _cursorLine, _cursorCol) {
+        return false;
+      },
+    }));
 
-		const previousFactory = ctx.ui.getEditorComponent();
-		ctx.ui.setEditorComponent((tui, theme, keybindings) => {
-			const baseEditor = previousFactory?.(tui, theme, keybindings);
-			currentEditor = new PathAutocompleteEditor(tui, theme, keybindings, baseEditor ?? undefined);
-			return currentEditor;
-		});
-	});
+    const previousFactory = ctx.ui.getEditorComponent();
+    ctx.ui.setEditorComponent((tui, theme, keybindings) => {
+      const baseEditor = previousFactory?.(tui, theme, keybindings);
+      currentEditor = new PathAutocompleteEditor(tui, theme, keybindings, baseEditor ?? undefined);
+      return currentEditor;
+    });
+  });
 
-	// ── /path command (standalone) ───────────────────────────────────
-	pi.registerCommand("path", {
-		description: "Fuzzy-search and insert a local git repo path",
-		getArgumentCompletions: (prefix): AutocompleteItem[] | null => {
-			const repos = getRepos();
-			const query = prefix.toLowerCase();
-			const items = repos.map((path) => ({
-				value: path,
-				label: shortenHome(path),
-			}));
-			const filtered = items.filter(
-				(item) => fuzzyMatch(query, item.label) || fuzzyMatch(query, item.value),
-			);
-			return filtered.length > 0 ? filtered.slice(0, 15) : null;
-		},
-		handler: async (args, ctx) => {
-			const repos = getRepos();
-			const query = (args ?? "").trim().toLowerCase();
+  // ── /path command (standalone) ───────────────────────────────────
+  pi.registerCommand("path", {
+    description: "Fuzzy-search and insert a local git repo path",
+    getArgumentCompletions: (prefix): AutocompleteItem[] | null => {
+      const repos = getRepos();
+      const query = prefix.toLowerCase();
+      const items = repos.map((path) => ({
+        value: path,
+        label: shortenHome(path),
+      }));
+      const filtered = items.filter(
+        (item) => fuzzyMatch(query, item.label) || fuzzyMatch(query, item.value),
+      );
+      return filtered.length > 0 ? filtered.slice(0, 15) : null;
+    },
+    handler: async (args, ctx) => {
+      const repos = getRepos();
+      const query = (args ?? "").trim().toLowerCase();
 
-			// If args provided, try to find a matching repo directly
-			if (query) {
-				const match = repos.find(
-					(path) => fuzzyMatch(query, shortenHome(path)) || fuzzyMatch(query, path),
-				);
-				if (match) {
-					ctx.ui.setEditorText(match);
-					ctx.ui.notify(`Inserted: ${shortenHome(match)}`, "info");
-					return;
-				}
-			}
+      // If args provided, try to find a matching repo directly
+      if (query) {
+        const match = repos.find(
+          (path) => fuzzyMatch(query, shortenHome(path)) || fuzzyMatch(query, path),
+        );
+        if (match) {
+          ctx.ui.setEditorText(match);
+          ctx.ui.notify(`Inserted: ${shortenHome(match)}`, "info");
+          return;
+        }
+      }
 
-			// No match — insert trigger so autocomplete dropdown appears
-			ctx.ui.setEditorText("/path:");
-			ctx.ui.notify("Type to filter repos, then select from dropdown", "info");
-		},
-	});
+      // No match — insert trigger so autocomplete dropdown appears
+      ctx.ui.setEditorText("/path:");
+      ctx.ui.notify("Type to filter repos, then select from dropdown", "info");
+    },
+  });
 
-	// ── Ctrl+Shift+R — insert trigger at cursor ──────────────────────
-	pi.registerShortcut("ctrl+shift+r", {
-		description: "Insert /path trigger at cursor to open repo autocomplete",
-		handler: async (ctx) => {
-			if (!currentEditor) {
-				ctx.ui.notify("Editor not ready", "error");
-				return;
-			}
-			currentEditor.insertTextAtCursor("/path:");
-			ctx.ui.notify("Type to filter repos, then select from dropdown", "info");
-		},
-	});
+  // ── Ctrl+Shift+R — insert trigger at cursor ──────────────────────
+  pi.registerShortcut("ctrl+shift+r", {
+    description: "Insert /path trigger at cursor to open repo autocomplete",
+    handler: async (ctx) => {
+      if (!currentEditor) {
+        ctx.ui.notify("Editor not ready", "error");
+        return;
+      }
+      currentEditor.insertTextAtCursor("/path:");
+      ctx.ui.notify("Type to filter repos, then select from dropdown", "info");
+    },
+  });
 }

--- a/shared/stow/pi/.pi/agent/extensions/ricekit.ts
+++ b/shared/stow/pi/.pi/agent/extensions/ricekit.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function ricekit(pi: ExtensionAPI) {
   pi.on("session_start", (_event, ctx) => {

--- a/shared/stow/pi/.pi/agent/extensions/scripts/validate.mjs
+++ b/shared/stow/pi/.pi/agent/extensions/scripts/validate.mjs
@@ -41,4 +41,6 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log(`validated ${extensionFiles.length} pi extension${extensionFiles.length === 1 ? "" : "s"}`);
+console.log(
+  `validated ${extensionFiles.length} pi extension${extensionFiles.length === 1 ? "" : "s"}`,
+);

--- a/shared/stow/pi/.pi/agent/extensions/startup-banner.ts
+++ b/shared/stow/pi/.pi/agent/extensions/startup-banner.ts
@@ -15,11 +15,15 @@ export default function (pi: ExtensionAPI) {
   let bannerDismissed = false;
   let activeCtx: ExtensionContext | undefined;
 
-  function branchHasConversation(ctx: { sessionManager: { getBranch(): Array<{ type: string }> } }): boolean {
+  function branchHasConversation(ctx: {
+    sessionManager: { getBranch(): Array<{ type: string }> };
+  }): boolean {
     return ctx.sessionManager.getBranch().some((entry) => entry.type === "message");
   }
 
-  function branchHasDismissal(ctx: { sessionManager: { getEntries(): Array<{ type: string; customType?: string }> } }): boolean {
+  function branchHasDismissal(ctx: {
+    sessionManager: { getEntries(): Array<{ type: string; customType?: string }> };
+  }): boolean {
     return ctx.sessionManager
       .getEntries()
       .some((entry) => entry.type === "custom" && entry.customType === "startup-banner-dismissed");
@@ -60,7 +64,8 @@ export default function (pi: ExtensionAPI) {
     bannerVisible = true;
     ctx.ui.setWidget("startup-banner", (_tui, theme) => {
       return {
-        render: (width: number) => art.map((line) => truncateToWidth(theme.fg("accent", line), width, "")),
+        render: (width: number) =>
+          art.map((line) => truncateToWidth(theme.fg("accent", line), width, "")),
         invalidate: () => {},
       };
     });

--- a/shared/stow/pi/.pi/agent/extensions/statusline.ts
+++ b/shared/stow/pi/.pi/agent/extensions/statusline.ts
@@ -1,10 +1,12 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { basename } from "node:path";
 
 const DIRTY_REFRESH_INTERVAL_MS = 10_000;
 
-function contextColor(percent: number | null | undefined): "success" | "warning" | "error" | "muted" {
+function contextColor(
+  percent: number | null | undefined,
+): "success" | "warning" | "error" | "muted" {
   if (percent === null || percent === undefined) return "muted";
   if (percent >= 90) return "error";
   if (percent >= 70) return "warning";
@@ -14,10 +16,18 @@ function contextColor(percent: number | null | undefined): "success" | "warning"
 function formatModel(model: unknown): string {
   if (!model || typeof model !== "object") return "no-model";
 
-  if ("name" in model && typeof (model as Record<string, unknown>).name === "string" && (model as Record<string, unknown>).name) {
+  if (
+    "name" in model &&
+    typeof (model as Record<string, unknown>).name === "string" &&
+    (model as Record<string, unknown>).name
+  ) {
     return (model as Record<string, unknown>).name as string;
   }
-  if ("id" in model && typeof (model as Record<string, unknown>).id === "string" && (model as Record<string, unknown>).id) {
+  if (
+    "id" in model &&
+    typeof (model as Record<string, unknown>).id === "string" &&
+    (model as Record<string, unknown>).id
+  ) {
     return (model as Record<string, unknown>).id as string;
   }
   return "model";
@@ -42,7 +52,10 @@ export default function statusline(pi: ExtensionAPI) {
     let dirtyTimer: ReturnType<typeof setInterval> | undefined;
 
     const refreshDirty = async () => {
-      const result = await pi.exec("git", ["status", "--porcelain"], { cwd: ctx.cwd, timeout: 5_000 });
+      const result = await pi.exec("git", ["status", "--porcelain"], {
+        cwd: ctx.cwd,
+        timeout: 5_000,
+      });
       if (disposed) return;
       const nextDirty = result.code === 0 && result.stdout.trim().length > 0;
       if (nextDirty !== dirty) {
@@ -70,11 +83,16 @@ export default function statusline(pi: ExtensionAPI) {
           const separator = theme.fg("dim", " │ ");
           const contextUsage = ctx.getContextUsage();
           const contextPercent = contextUsage?.percent;
-          const contextText = theme.fg(contextColor(contextPercent), formatContextPercent(contextPercent));
+          const contextText = theme.fg(
+            contextColor(contextPercent),
+            formatContextPercent(contextPercent),
+          );
 
           const directory = basename(ctx.cwd) || ctx.cwd;
           const branch = footerData.getGitBranch();
-          const branchText = branch ? ` ${theme.fg("success", `(${branch}${dirty ? theme.fg("error", "*") : ""})`)}` : "";
+          const branchText = branch
+            ? ` ${theme.fg("success", `(${branch}${dirty ? theme.fg("error", "*") : ""})`)}`
+            : "";
 
           // Calculate accumulated cost from all session entries
           let totalCost = 0;
@@ -94,7 +112,9 @@ export default function statusline(pi: ExtensionAPI) {
             usageParts.push(costStr);
           }
 
-          const extensionStatuses = Array.from(footerData.getExtensionStatuses?.() ?? new Map<string, string>())
+          const extensionStatuses = Array.from(
+            footerData.getExtensionStatuses?.() ?? new Map<string, string>(),
+          )
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([, text]) => text);
 

--- a/shared/stow/pi/.pi/agent/extensions/subagent.ts
+++ b/shared/stow/pi/.pi/agent/extensions/subagent.ts
@@ -3,15 +3,15 @@ import { existsSync } from "node:fs";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
   formatSize,
   truncateTail,
   withFileMutationQueue,
-} from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 type MessageContent = { type: "text"; text: string } | { type: string; [key: string]: unknown };
@@ -57,7 +57,8 @@ const KILL_GRACE_MS = 5_000;
 
 const SubagentParams = Type.Object({
   task: Type.String({
-    description: "Focused task for the subagent to complete. Include all context the subagent needs.",
+    description:
+      "Focused task for the subagent to complete. Include all context the subagent needs.",
   }),
   role: Type.Optional(
     Type.String({
@@ -67,17 +68,20 @@ const SubagentParams = Type.Object({
   ),
   cwd: Type.Optional(
     Type.String({
-      description: "Working directory for the subagent. Relative paths resolve against the current pi cwd.",
+      description:
+        "Working directory for the subagent. Relative paths resolve against the current pi cwd.",
     }),
   ),
   model: Type.Optional(
     Type.String({
-      description: "Optional pi model pattern/id for the subagent, e.g. 'sonnet:high' or 'openai/gpt-5.5'.",
+      description:
+        "Optional pi model pattern/id for the subagent, e.g. 'sonnet:high' or 'openai/gpt-5.5'.",
     }),
   ),
   tools: Type.Optional(
     Type.Array(Type.String(), {
-      description: "Optional allowlist of tool names for the subagent, e.g. ['read','grep','find','ls'].",
+      description:
+        "Optional allowlist of tool names for the subagent, e.g. ['read','grep','find','ls'].",
     }),
   ),
   timeoutMs: Type.Optional(
@@ -104,7 +108,10 @@ function getPiInvocation(args: string[]): { command: string; args: string[] } {
 
 function getText(message: AssistantMessage): string {
   return (message.content ?? [])
-    .filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        part.type === "text" && typeof part.text === "string",
+    )
     .map((part) => part.text)
     .join("\n");
 }
@@ -230,7 +237,10 @@ async function runSubagent(params: {
       }, KILL_GRACE_MS);
     };
 
-    const timeoutTimer = setTimeout(() => kill(`Subagent timed out after ${params.timeoutMs}ms.`), params.timeoutMs);
+    const timeoutTimer = setTimeout(
+      () => kill(`Subagent timed out after ${params.timeoutMs}ms.`),
+      params.timeoutMs,
+    );
 
     const processLine = (line: string) => {
       if (!line.trim()) return;
@@ -244,7 +254,12 @@ async function runSubagent(params: {
 
       if (!event || typeof event !== "object") return;
       const candidate = event as { type?: unknown; message?: unknown };
-      if (candidate.type !== "message_end" || !candidate.message || typeof candidate.message !== "object") return;
+      if (
+        candidate.type !== "message_end" ||
+        !candidate.message ||
+        typeof candidate.message !== "object"
+      )
+        return;
 
       const message = candidate.message as AssistantMessage;
       if (message.role !== "assistant") return;
@@ -292,7 +307,8 @@ async function runSubagent(params: {
 
 function formatUsage(details: SubagentDetails): string {
   const parts: string[] = [];
-  if (details.usage.turns) parts.push(`${details.usage.turns} turn${details.usage.turns === 1 ? "" : "s"}`);
+  if (details.usage.turns)
+    parts.push(`${details.usage.turns} turn${details.usage.turns === 1 ? "" : "s"}`);
   if (details.usage.input) parts.push(`↑${details.usage.input}`);
   if (details.usage.output) parts.push(`↓${details.usage.output}`);
   if (details.usage.cacheRead) parts.push(`R${details.usage.cacheRead}`);
@@ -307,7 +323,8 @@ export default function subagent(pi: ExtensionAPI) {
     label: "Subagent",
     description:
       "Delegate a focused task to a separate pi process with an isolated context window. Useful for research, exploration, review, and parallelizable analysis. Output is truncated to safe limits if necessary.",
-    promptSnippet: "Delegate focused research, exploration, review, or analysis to an isolated pi process.",
+    promptSnippet:
+      "Delegate focused research, exploration, review, or analysis to an isolated pi process.",
     promptGuidelines: [
       "Use subagent for focused research or analysis tasks that would otherwise clutter the main context.",
       "Give subagent all relevant context in the task because it runs in an isolated session.",
@@ -346,7 +363,9 @@ export default function subagent(pi: ExtensionAPI) {
 
       const output = await maybeTruncateOutput(details);
       const isError = details.exitCode !== 0;
-      const text = isError ? `Subagent failed with exit code ${details.exitCode}.\n\n${output}` : output;
+      const text = isError
+        ? `Subagent failed with exit code ${details.exitCode}.\n\n${output}`
+        : output;
 
       return {
         content: [{ type: "text", text }],
@@ -357,7 +376,9 @@ export default function subagent(pi: ExtensionAPI) {
     renderCall(args, theme) {
       const task = typeof args.task === "string" ? args.task : "...";
       const preview = task.length > 80 ? `${task.slice(0, 80)}...` : task;
-      let text = theme.fg("toolTitle", theme.bold("subagent ")) + theme.fg("accent", args.model ?? "default model");
+      let text =
+        theme.fg("toolTitle", theme.bold("subagent ")) +
+        theme.fg("accent", args.model ?? "default model");
       if (args.cwd) text += theme.fg("muted", ` in ${args.cwd}`);
       text += `\n  ${theme.fg("dim", preview)}`;
       return new Text(text, 0, 0);
@@ -384,11 +405,13 @@ export default function subagent(pi: ExtensionAPI) {
         text += `\n\n${theme.fg("muted", "cwd: ")}${theme.fg("dim", details.cwd)}`;
         text += `\n${theme.fg("muted", "task: ")}${theme.fg("dim", details.task)}`;
         if (details.stderr.trim()) text += `\n\n${theme.fg("error", details.stderr.trim())}`;
-        if (details.finalOutput.trim()) text += `\n\n${theme.fg("toolOutput", details.finalOutput.trim())}`;
+        if (details.finalOutput.trim())
+          text += `\n\n${theme.fg("toolOutput", details.finalOutput.trim())}`;
       } else if (details.finalOutput.trim()) {
         const preview = details.finalOutput.trim().split("\n").slice(0, 8).join("\n");
         text += `\n${theme.fg("toolOutput", preview)}`;
-        if (details.finalOutput.trim().split("\n").length > 8) text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
+        if (details.finalOutput.trim().split("\n").length > 8)
+          text += `\n${theme.fg("muted", "(Ctrl+O to expand)")}`;
       }
 
       return new Text(text, 0, 0);

--- a/shared/stow/pi/.pi/agent/extensions/tests/shoehorn.test.ts
+++ b/shared/stow/pi/.pi/agent/extensions/tests/shoehorn.test.ts
@@ -1,0 +1,21 @@
+import { fromPartial } from "@total-typescript/shoehorn";
+
+type RenderedToolResult = {
+  content: Array<{
+    type: "text";
+    text: string;
+  }>;
+  details: {
+    ok: boolean;
+  };
+};
+
+describe("shoehorn test fixtures", () => {
+  it("lets tests pass only the fields they care about", () => {
+    const result: RenderedToolResult = fromPartial({
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    expect(result.content[0]?.text).toBe("ok");
+  });
+});

--- a/shared/stow/pi/.pi/agent/extensions/tsconfig.json
+++ b/shared/stow/pi/.pi/agent/extensions/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node", "jest"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts", "tests/**/*.ts"],
+  "exclude": [".turbo", "coverage", "node_modules"]
+}

--- a/shared/stow/pi/.pi/agent/extensions/workspace-switcher.ts
+++ b/shared/stow/pi/.pi/agent/extensions/workspace-switcher.ts
@@ -1,9 +1,9 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, isAbsolute, join, resolve } from "node:path";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
-import type { AutocompleteItem } from "@mariozechner/pi-tui";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
 
 interface WorkspaceConfig {
   default?: string;
@@ -143,7 +143,10 @@ let workspaceConfig: WorkspaceConfig = {};
 let appendState: ((customType: string, data?: unknown) => void) | null = null;
 
 function piAppendWorkspaceState(workspace: WorkspaceState) {
-  appendState?.(STATE_ENTRY, workspace ? { alias: workspace.alias, path: workspace.path } : { alias: null, path: null });
+  appendState?.(
+    STATE_ENTRY,
+    workspace ? { alias: workspace.alias, path: workspace.path } : { alias: null, path: null },
+  );
 }
 
 function updateStatus(ctx: ExtensionContext) {
@@ -155,12 +158,15 @@ function findWorkspace(query: string): Workspace | undefined {
   const trimmed = query.trim();
   if (!trimmed) return undefined;
 
-  const exact = workspaces.find((workspace) => workspace.alias === trimmed || workspace.path === expandHome(trimmed));
+  const exact = workspaces.find(
+    (workspace) => workspace.alias === trimmed || workspace.path === expandHome(trimmed),
+  );
   if (exact) return exact;
 
   const lower = trimmed.toLowerCase();
   const fuzzy = workspaces.find(
-    (workspace) => workspace.alias.toLowerCase().includes(lower) || workspace.path.toLowerCase().includes(lower),
+    (workspace) =>
+      workspace.alias.toLowerCase().includes(lower) || workspace.path.toLowerCase().includes(lower),
   );
   if (fuzzy) return fuzzy;
 
@@ -181,7 +187,10 @@ function completionItems(prefix: string): AutocompleteItem[] | null {
   }));
   const lower = prefix.trim().toLowerCase();
   const items = [...builtins, ...configured].filter(
-    (item) => !lower || item.value.toLowerCase().includes(lower) || item.label.toLowerCase().includes(lower),
+    (item) =>
+      !lower ||
+      item.value.toLowerCase().includes(lower) ||
+      item.label.toLowerCase().includes(lower),
   );
   return items.length > 0 ? items : null;
 }
@@ -189,7 +198,10 @@ function completionItems(prefix: string): AutocompleteItem[] | null {
 function latestPersistedWorkspace(ctx: ExtensionContext): WorkspaceState | undefined {
   const entry = ctx.sessionManager
     .getBranch()
-    .filter((e: { type: string; customType?: string }) => e.type === "custom" && e.customType === STATE_ENTRY)
+    .filter(
+      (e: { type: string; customType?: string }) =>
+        e.type === "custom" && e.customType === STATE_ENTRY,
+    )
     .pop() as { data?: { alias?: unknown; path?: unknown } } | undefined;
 
   if (!entry) return undefined;
@@ -225,7 +237,10 @@ function resolveRequiredPathInput(input: Record<string, unknown>, workspace: Wor
   }
 }
 
-function mutateToolInputForWorkspace(event: { toolName: string; input: unknown }, workspace: Workspace) {
+function mutateToolInputForWorkspace(
+  event: { toolName: string; input: unknown },
+  workspace: Workspace,
+) {
   if (event.toolName === "bash" && event.input && typeof event.input === "object") {
     const input = event.input as Record<string, unknown>;
     if (typeof input.command === "string") {
@@ -251,7 +266,10 @@ function mutateToolInputForWorkspace(event: { toolName: string; input: unknown }
     if (typeof input.cwd !== "string") input.cwd = workspace.path;
   }
 
-  if ((event.toolName === "peb_plan" || event.toolName === "peb_sync_github") && typeof input.repo !== "string") {
+  if (
+    (event.toolName === "peb_plan" || event.toolName === "peb_sync_github") &&
+    typeof input.repo !== "string"
+  ) {
     input.repo = workspace.path;
   }
 }
@@ -294,9 +312,10 @@ export default function workspaceSwitcher(pi: ExtensionAPI) {
       }
 
       if (arg === "list") {
-        const body = workspaces.length > 0
-          ? workspaces.map((workspace) => `- ${describeWorkspace(workspace)}`).join("\n")
-          : "No workspaces configured. Add ~/.pi/agent/workspaces.json.";
+        const body =
+          workspaces.length > 0
+            ? workspaces.map((workspace) => `- ${describeWorkspace(workspace)}`).join("\n")
+            : "No workspaces configured. Add ~/.pi/agent/workspaces.json.";
         ctx.ui.notify(body, "info");
         return;
       }
@@ -323,13 +342,19 @@ export default function workspaceSwitcher(pi: ExtensionAPI) {
           return;
         }
         setActiveWorkspace(ctx, selected);
-        ctx.ui.notify(selected ? `Active workspace: ${describeWorkspace(selected)}` : "Workspace cleared", "info");
+        ctx.ui.notify(
+          selected ? `Active workspace: ${describeWorkspace(selected)}` : "Workspace cleared",
+          "info",
+        );
         return;
       }
 
       const workspace = findWorkspace(arg);
       if (!workspace) {
-        ctx.ui.notify(`Unknown workspace: ${arg}. Run /repo list to see configured aliases.`, "error");
+        ctx.ui.notify(
+          `Unknown workspace: ${arg}. Run /repo list to see configured aliases.`,
+          "error",
+        );
         return;
       }
 

--- a/shared/stow/pi/.pi/agent/package.json
+++ b/shared/stow/pi/.pi/agent/package.json
@@ -3,9 +3,14 @@
   "private": true,
   "packageManager": "pnpm@10.22.0",
   "scripts": {
+    "format": "turbo run format",
+    "format:check": "turbo run format:check",
+    "lint": "turbo run lint",
+    "test": "turbo run test",
+    "typecheck": "turbo run typecheck",
     "validate": "turbo run validate"
   },
   "devDependencies": {
-    "turbo": "^2.5.8"
+    "turbo": "^2.9.14"
   }
 }

--- a/shared/stow/pi/.pi/agent/pnpm-lock.yaml
+++ b/shared/stow/pi/.pi/agent/pnpm-lock.yaml
@@ -9,174 +9,1127 @@ importers:
   .:
     devDependencies:
       turbo:
-        specifier: ^2.5.8
+        specifier: ^2.9.14
         version: 2.9.14
 
   extensions:
     devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.75.4
+        version: 0.75.4(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.75.4
+        version: 0.75.4(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.75.4
+        version: 0.75.4
+      '@swc/core':
+        specifier: ^1.15.33
+        version: 1.15.33
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.33)
+      '@total-typescript/shoehorn':
+        specifier: ^0.1.2
+        version: 0.1.2
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260522.1
+        version: 7.0.0-dev.20260522.1
       esbuild:
-        specifier: ^0.25.5
-        version: 0.25.12
+        specifier: ^0.28.0
+        version: 0.28.0
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@25.9.1)
+      oxfmt:
+        specifier: ^0.51.0
+        version: 0.51.0
+      oxlint:
+        specifier: ^1.66.0
+        version: 1.66.0
+      typebox:
+        specifier: ^1.1.38
+        version: 1.1.38
 
   packages/config: {}
 
 packages:
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.13':
+    resolution: {integrity: sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.39':
+    resolution: {integrity: sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.41':
+    resolution: {integrity: sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.43':
+    resolution: {integrity: sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.43':
+    resolution: {integrity: sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.44':
+    resolution: {integrity: sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.39':
+    resolution: {integrity: sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.43':
+    resolution: {integrity: sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.43':
+    resolution: {integrity: sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.17':
+    resolution: {integrity: sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.13':
+    resolution: {integrity: sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.21':
+    resolution: {integrity: sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.11':
+    resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.28':
+    resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1052.0':
+    resolution: {integrity: sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.25':
+    resolution: {integrity: sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-async-generators@7.8.4':
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-bigint@7.8.3':
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-properties@7.12.13':
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-static-block@7.14.5':
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-attributes@7.28.6':
+    resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-meta@7.10.4':
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-json-strings@7.8.3':
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4':
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3':
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3':
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3':
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5':
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-top-level-await@7.14.5':
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@earendil-works/pi-agent-core@0.75.4':
+    resolution: {integrity: sha512-cGYbysb4EqUf0B28OeqFq2ppm1XF3bYBOP71q9dv38yf/UJfzMjiXBeNelrcio+QWIoVrW+xzYm7sMzYIUc9Og==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.75.4':
+    resolution: {integrity: sha512-m/w8Hh3vQ0rAycwJiJWdzkypkn4295f4eq/966lDRy8aX5sk6bgYXH8TQmL16TO7Uwc7MbJG0QoyFHgX8RqXUQ==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.75.4':
+    resolution: {integrity: sha512-Fb+FRo08b5H9pYKbQJ708/5OKL0+K/yclhfCMEhrBzSPTZZ4c85nY1YsBo4qwL20ohBMlBezHMRuHzcJ1ylEoQ==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.75.4':
+    resolution: {integrity: sha512-PDhKU7u6fmEcvHUFHzrRwGc/Ytokj/hO+X4RPf+MWKEGpvg3B1vHv88Ee+Dy33004tYkQF5YeXV4btJZcp5x1g==}
+    engines: {node: '>=22.19.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jest/console@30.4.1':
+    resolution: {integrity: sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/core@30.4.2':
+    resolution: {integrity: sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/create-cache-key-function@30.4.1':
+    resolution: {integrity: sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/diff-sequences@30.4.0':
+    resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/environment@30.4.1':
+    resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect-utils@30.4.1':
+    resolution: {integrity: sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect@30.4.1':
+    resolution: {integrity: sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/fake-timers@30.4.1':
+    resolution: {integrity: sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/globals@30.4.1':
+    resolution: {integrity: sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/pattern@30.4.0':
+    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/reporters@30.4.1':
+    resolution: {integrity: sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/schemas@30.4.1':
+    resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/snapshot-utils@30.4.1':
+    resolution: {integrity: sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/source-map@30.0.1':
+    resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-result@30.4.1':
+    resolution: {integrity: sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-sequencer@30.4.1':
+    resolution: {integrity: sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/transform@30.4.1':
+    resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/types@30.4.1':
+    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.6':
+    resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.6':
+    resolution: {integrity: sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.6':
+    resolution: {integrity: sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
+    resolution: {integrity: sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
+    resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
+    resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
+    resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
+    resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
+    resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
+    resolution: {integrity: sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.6':
+    resolution: {integrity: sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==}
+    engines: {node: '>= 10'}
+
+  '@mistralai/mistralai@2.2.1':
+    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@oxfmt/binding-android-arm-eabi@0.51.0':
+    resolution: {integrity: sha512-Ni0sCqg5CIHaLIYFGj+ncbcumylvNC6FE4rfD0KfdmnWHbPJ+zev0qZCXKxy2hFVa0fYRK0yPzf5nzPbkZou7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.51.0':
+    resolution: {integrity: sha512-eu5lAZjuo0KAkp+M24EhDqfOwA8owQ8d7wyBlOUUGRbDLHpU3IRlDHp8Dif+YqGlxs6jra7yS6WQu/NkPhAxeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.51.0':
+    resolution: {integrity: sha512-6LsUNIdURhhcIfIn8+xsOb61mSTa9msAHTeSGx9Jf4rsP/gN8PGCF+SKWPAQZbND2w/WBkqQ6303jqEEIXzMdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.51.0':
+    resolution: {integrity: sha512-9aUMGmVxdHjYMsEAW1tNRoieTJXlVNDFkRvIR1J7LttJXWjVYCu2ekclLij2KJtxBxSQOYSHd12ME/adVGVbZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.51.0':
+    resolution: {integrity: sha512-mkY1nhZTqYb+NHaAWxOCKISN6FwdrwMNsu17vTUA3wzUV2VJ+Paq15ZokRcsMU/2PUdHO73prxyeJpjXQ3MPpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.51.0':
+    resolution: {integrity: sha512-wtFwNwE4+YCNuPaWoGDZeGsKvD6D1YSUNBJNn/rJBh7CrDBThFE+TBI5kY7vRW9rIOQRsbW2IpyyL3Du4Zqwiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.51.0':
+    resolution: {integrity: sha512-rnOaNx86G7iRKM6lsCIQMux0SMGNC/TEbFR+r7lpruJ12bnrIWgxd5w1PLqOvgR9r8ZJbpK/zfRKctJnh8/Jfg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.51.0':
+    resolution: {integrity: sha512-jOgDzSqWcICGRjsp4mc08FxKMN8vzP2Kgs4E0d2HUP99F+nJDQKklRV4Zuj+0gcBgjrzx2CbpqaIdUVPepCojA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-musl@0.51.0':
+    resolution: {integrity: sha512-KBUCdrH5bwVrAvI9gU/1S55oH6fzXjr++J/oVocdu7bYTks1l7DNNT+rLd/1TDdAEjObGwmfWamn7LC1m8A0DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.51.0':
+    resolution: {integrity: sha512-NapfjYsABFqTJ1Dn9Efq6sN5esaHconVKwVLbDGNQLrwpOx/g17mkwErHzU72PutL67nf3wNAkbq122H+zLxag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.51.0':
+    resolution: {integrity: sha512-5dlDt1dUZCVi6elIhiK1PWg9wpTzTcIuj0IZnSurvIoMrhOWqqTcc1dSTxcSkNaBZhfsNqRZdINI1zAgbKkJNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.51.0':
+    resolution: {integrity: sha512-pgdWUJn0S5nulyiVdlFV8DzCUnGXkU99W5PSkkmbaZW+LrZBPxpezun4G0DDHbQaVYuJeCuKsXsGKGo77CkUTQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.51.0':
+    resolution: {integrity: sha512-2XTFUe97CbDGAI8vjwDfZ1HdakO0XIADyJ24idEg64SC4/K4in/OisXVnrW4NMK7I6TgC7EqRhC0Ln/nKhAemA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-gnu@0.51.0':
+    resolution: {integrity: sha512-kQ1OuCqqt/yyf0ZN9VFxW1/JnlgJgii3Dr7pWf9vNBvrX1hv6g39/+mc5oGRHRGJFZtl3zsGDWR9c5N2B/gwBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-musl@0.51.0':
+    resolution: {integrity: sha512-ARTYqxHF475o96Gbn41hvSWSSRygPlRDXZZgZ9I2scU1y0qiWpCQyZCoefaQa0mwv+wwtZ+luS4YOzsRzM/izg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-openharmony-arm64@0.51.0':
+    resolution: {integrity: sha512-QiC1XrCl6a6BmqMzduO8hdIRMf1m44hCkt2Q68KWkTvUB/E7fd2iomyNh6KnnRca5w6eBrRAAtLFqTh+xjsjJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.51.0':
+    resolution: {integrity: sha512-NC/hJb9dtU23Zf8L7IVK95xnFjiQ7AfcLO2l5pb69TDEr958qxrtnB2CveeeNSCBFNIkgaTCfd/vHNSoG78l9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.51.0':
+    resolution: {integrity: sha512-2C45za4Rj36n8YIbhRL1PQbxmXJYf81WEcAgvj5I4ptRROG+A+81hREEN5bmCHADE1UfYaN312U6tkILoZZy6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.51.0':
+    resolution: {integrity: sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.66.0':
+    resolution: {integrity: sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.66.0':
+    resolution: {integrity: sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.66.0':
+    resolution: {integrity: sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.66.0':
+    resolution: {integrity: sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.66.0':
+    resolution: {integrity: sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
+    resolution: {integrity: sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
+    resolution: {integrity: sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.66.0':
+    resolution: {integrity: sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-musl@1.66.0':
+    resolution: {integrity: sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
+    resolution: {integrity: sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
+    resolution: {integrity: sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.66.0':
+    resolution: {integrity: sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.66.0':
+    resolution: {integrity: sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.66.0':
+    resolution: {integrity: sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-musl@1.66.0':
+    resolution: {integrity: sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-openharmony-arm64@1.66.0':
+    resolution: {integrity: sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.66.0':
+    resolution: {integrity: sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.66.0':
+    resolution: {integrity: sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.66.0':
+    resolution: {integrity: sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@sinclair/typebox@0.34.49':
+    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@smithy/core@3.24.4':
+    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.4':
+    resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.4':
+    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.4':
+    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.4':
+    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@swc/core-darwin-arm64@1.15.33':
+    resolution: {integrity: sha512-N+L0uXhuO7FIfzqwgxmzv0zIpV0qEp8wPX3QQs2p4atjMoywup2JTeDlXPw+z9pWJGCae3JjM+tZ6myclI+2gA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.33':
+    resolution: {integrity: sha512-/Il4QHSOhV4FekbsDtkrNmKbsX26oSysvgrRswa/RYOHXAkwXDbB4jaeKq6PsJLSPkzJ2KzQ061gtBnk0vNHfA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.33':
+    resolution: {integrity: sha512-C64hBnBxq4viOPQ8hlx+2lJ23bzZBGnjw7ryALmS+0Q3zHmwO8lw1/DArLENw4Q18/0w5wdEO1k3m1wWNtKGqQ==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.33':
+    resolution: {integrity: sha512-TRJfnJbX3jqpxRDRoieMzRiCBS5jOmXNb3iQXmcgjFEHKLnAgK1RZRU8Cq1MsPqO4jAJp/ld1G4O3fXuxv85uw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.33':
+    resolution: {integrity: sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.33':
+    resolution: {integrity: sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.33':
+    resolution: {integrity: sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.33':
+    resolution: {integrity: sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.33':
+    resolution: {integrity: sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.33':
+    resolution: {integrity: sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.33':
+    resolution: {integrity: sha512-gtyvzSNR8DHKfFEA2uqb8Ld1myqi6uEg2jyeUq3ikn5ytYs7H8RpZYC8mdy4NXr8hfcdJfCLXPlYaqqfBXpoEQ==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.33':
+    resolution: {integrity: sha512-d6fRqQSkJI+kmMEBWaDQ7TMl8+YjLYbwRUPZQ9DY0ORBJeTzOrG0twvfvlZ2xgw6jA0ScQKgfBm4vHLSLl5Hqg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.33':
+    resolution: {integrity: sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/jest@0.2.39':
+    resolution: {integrity: sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
+
+  '@total-typescript/shoehorn@0.1.2':
+    resolution: {integrity: sha512-p7nNZbOZIofpDNyP0u1BctFbjxD44Qc+oO5jufgQdFdGIXJLc33QRloJpq7k5T59CTgLWfQSUxsuqLcmeurYRw==}
 
   '@turbo/darwin-64@2.9.14':
     resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
@@ -208,94 +1161,2429 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@30.0.0':
+    resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-kp2JX8wSCQ5i8f5Zr30t9TdAIEw8s3MCvT1zEe6PJAHU7aUHTnRCM+oAHEM8QxM29VD/PxR6b5dVKxHtX7Ny/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-jX89E/hV/r0fOcP4+JWdKSugJXmWbOO74aC5a1U8+U7TBD1TTfK50Da+BL8Sf2Xud2ybqQ+2FUHAlBsLTC743g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-XFLpJNscLKqT6LLSBrv78DzLdzwFYOePeluRBF616KUPEcfiXliTan1YuHQh4m9i9o6tvW/NnuAPlr/Q8DObsg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-vItWfPtZfUQLaVJe0iClfsKSDtkUCUTp2LfEXBHqBCdWhoE3irg7Ivs41l3sp4zXlTio5SUvMzvO8/Mc2SImzA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-r5wkbqL+qpI3QN3GiF0dg5A0PD5x9cfYSSCD744+Ov35P8inuJSySjR44gdoOF3IcFTupPEc/4q4to/gId1kZQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-Xtqw0dfE35WISVqN2J9hp21N6l5MT21DSgJ4w/cXisDZlaeT0Vq57CgUWUbLT4CEw5gs0QK6kmUFOSAP7Dga6Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-CBTpf7skuTNgHzjwEbw3ujU76r/u9asENXc9xQmgj6qCJ1+ZHn34MMzolkUegwtHWfuem38ayYTJOMn2dmNQ5g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-NgnE3PE3/nr4Qr8p1uCIkaM5YmNa8hQGhzb8Olb6w09aocg4Wq8bjrFHe4qZH2kgV+Hl4gGXRNb9ww1P2fwc9Q==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    resolution: {integrity: sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    resolution: {integrity: sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    resolution: {integrity: sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    resolution: {integrity: sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    resolution: {integrity: sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    resolution: {integrity: sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    resolution: {integrity: sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    resolution: {integrity: sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    resolution: {integrity: sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
+    cpu: [x64]
+    os: [win32]
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  babel-jest@30.4.1:
+    resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@babel/core': ^7.11.0 || ^8.0.0-0
+
+  babel-plugin-istanbul@7.0.1:
+    resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
+    engines: {node: '>=12'}
+
+  babel-plugin-jest-hoist@30.4.0:
+    resolution: {integrity: sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  babel-preset-current-node-syntax@1.2.0:
+    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0 || ^8.0.0-0
+
+  babel-preset-jest@30.4.0:
+    resolution: {integrity: sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@babel/core': ^7.11.0 || ^8.0.0-beta.1
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  collect-v8-coverage@1.0.3:
+    resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  electron-to-chromium@1.5.361:
+    resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
+
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  exit-x@0.2.2:
+    resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
+    engines: {node: '>= 0.8.0'}
+
+  expect@30.4.1:
+    resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jest-changed-files@30.4.1:
+    resolution: {integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-circus@30.4.2:
+    resolution: {integrity: sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-cli@30.4.2:
+    resolution: {integrity: sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@30.4.2:
+    resolution: {integrity: sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      esbuild-register: '>=3.4.0'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild-register:
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@30.4.1:
+    resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-docblock@30.4.0:
+    resolution: {integrity: sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-each@30.4.1:
+    resolution: {integrity: sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-environment-node@30.4.1:
+    resolution: {integrity: sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-haste-map@30.4.1:
+    resolution: {integrity: sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-leak-detector@30.4.1:
+    resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-matcher-utils@30.4.1:
+    resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-message-util@30.4.1:
+    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-mock@30.4.1:
+    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-pnp-resolver@1.2.3:
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
+  jest-regex-util@30.4.0:
+    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve-dependencies@30.4.2:
+    resolution: {integrity: sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve@30.4.1:
+    resolution: {integrity: sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-runner@30.4.2:
+    resolution: {integrity: sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-runtime@30.4.2:
+    resolution: {integrity: sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-snapshot@30.4.1:
+    resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-util@30.4.1:
+    resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-validate@30.4.1:
+    resolution: {integrity: sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-watcher@30.4.1:
+    resolution: {integrity: sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-worker@30.4.1:
+    resolution: {integrity: sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest@30.4.2:
+    resolution: {integrity: sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  koffi@2.16.2:
+    resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.0:
+    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  oxfmt@0.51.0:
+    resolution: {integrity: sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  oxlint@1.66.0:
+    resolution: {integrity: sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
+
+  pretty-format@30.4.1:
+    resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+    engines: {node: '>=12.0.0'}
+
+  pure-rand@7.0.1:
+    resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-is@19.2.6:
+    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
 
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@8.3.0:
+    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+    engines: {node: '>=22.19.0'}
+
+  unrs-resolver@1.12.2:
+    resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
-  '@esbuild/aix-ppc64@0.25.12':
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/credential-provider-node': 3.972.44
+      '@aws-sdk/eventstream-handler-node': 3.972.17
+      '@aws-sdk/middleware-eventstream': 3.972.13
+      '@aws-sdk/middleware-websocket': 3.972.21
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.25
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/credential-provider-env': 3.972.39
+      '@aws-sdk/credential-provider-http': 3.972.41
+      '@aws-sdk/credential-provider-login': 3.972.43
+      '@aws-sdk/credential-provider-process': 3.972.39
+      '@aws-sdk/credential-provider-sso': 3.972.43
+      '@aws-sdk/credential-provider-web-identity': 3.972.43
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.44':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.39
+      '@aws-sdk/credential-provider-http': 3.972.41
+      '@aws-sdk/credential-provider-ini': 3.972.43
+      '@aws-sdk/credential-provider-process': 3.972.39
+      '@aws-sdk/credential-provider-sso': 3.972.43
+      '@aws-sdk/credential-provider-web-identity': 3.972.43
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/token-providers': 3.1052.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.17':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.21':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.11':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.28':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1052.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.25':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@0.2.3': {}
+
+  '@earendil-works/pi-agent-core@0.75.4(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.75.4(ws@8.21.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.75.4(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.1
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.75.4(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.75.4(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.75.4(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.75.4
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      typebox: 1.1.38
+      undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.6
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.75.4':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 15.0.12
+    optionalDependencies:
+      koffi: 2.16.2
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-arm64@0.25.12':
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-x64@0.25.12':
+  '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.12':
+  '@esbuild/android-arm@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.12':
+  '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm@0.25.12':
+  '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.12':
+  '@esbuild/linux-arm64@0.28.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.12':
+  '@esbuild/linux-ia32@0.28.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.12':
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.12':
+  '@esbuild/linux-mips64el@0.28.0':
     optional: true
 
-  '@esbuild/linux-x64@0.25.12':
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.12':
+  '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.12':
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.12':
+  '@esbuild/linux-x64@0.28.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.12':
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.12':
+  '@esbuild/netbsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.12':
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.12':
+  '@esbuild/openbsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.12':
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
-  '@esbuild/win32-x64@0.25.12':
+  '@esbuild/sunos-x64@0.28.0':
     optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.6.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.14.2
+      resolve-from: 5.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jest/console@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      chalk: 4.1.2
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      slash: 3.0.0
+
+  '@jest/core@30.4.2':
+    dependencies:
+      '@jest/console': 30.4.1
+      '@jest/pattern': 30.4.0
+      '@jest/reporters': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.4.1
+      jest-config: 30.4.2(@types/node@24.12.4)
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-resolve-dependencies: 30.4.2
+      jest-runner: 30.4.2
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      jest-watcher: 30.4.1
+      pretty-format: 30.4.1
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/create-cache-key-function@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+
+  '@jest/diff-sequences@30.4.0': {}
+
+  '@jest/environment@30.4.1':
+    dependencies:
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      jest-mock: 30.4.1
+
+  '@jest/expect-utils@30.4.1':
+    dependencies:
+      '@jest/get-type': 30.1.0
+
+  '@jest/expect@30.4.1':
+    dependencies:
+      expect: 30.4.1
+      jest-snapshot: 30.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/fake-timers@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+      '@sinonjs/fake-timers': 15.4.0
+      '@types/node': 24.12.4
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+
+  '@jest/get-type@30.1.0': {}
+
+  '@jest/globals@30.4.1':
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/types': 30.4.1
+      jest-mock: 30.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/pattern@30.4.0':
+    dependencies:
+      '@types/node': 24.12.4
+      jest-regex-util: 30.4.0
+
+  '@jest/reporters@30.4.1':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 24.12.4
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit-x: 0.2.2
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
+      slash: 3.0.0
+      string-length: 4.0.2
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/schemas@30.4.1':
+    dependencies:
+      '@sinclair/typebox': 0.34.49
+
+  '@jest/snapshot-utils@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      natural-compare: 1.4.0
+
+  '@jest/source-map@30.0.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/test-result@30.4.1':
+    dependencies:
+      '@jest/console': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+
+  '@jest/test-sequencer@30.4.1':
+    dependencies:
+      '@jest/test-result': 30.4.1
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.4.1
+      slash: 3.0.0
+
+  '@jest/transform@30.4.1':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/types': 30.4.1
+      '@jridgewell/trace-mapping': 0.3.31
+      babel-plugin-istanbul: 7.0.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/types@30.4.1':
+    dependencies:
+      '@jest/pattern': 30.4.0
+      '@jest/schemas': 30.4.1
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 24.12.4
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.6':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.6
+      '@mariozechner/clipboard-darwin-universal': 0.3.6
+      '@mariozechner/clipboard-darwin-x64': 0.3.6
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.6
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.6
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.6
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.6
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.6
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.6
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.6
+    optional: true
+
+  '@mistralai/mistralai@2.2.1':
+    dependencies:
+      ws: 8.21.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@nodable/entities@2.1.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.51.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.66.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.66.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.66.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.66.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.66.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.66.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.66.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.66.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.66.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.66.0':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@pkgr/core@0.2.9': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@sinclair/typebox@0.34.49': {}
+
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@15.4.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@smithy/core@3.24.4':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@swc/core-darwin-arm64@1.15.33':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.33':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.33':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.33':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.33':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.33':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.33':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.33':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.33':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.33':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.33':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.33':
+    optional: true
+
+  '@swc/core@1.15.33':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.33
+      '@swc/core-darwin-x64': 1.15.33
+      '@swc/core-linux-arm-gnueabihf': 1.15.33
+      '@swc/core-linux-arm64-gnu': 1.15.33
+      '@swc/core-linux-arm64-musl': 1.15.33
+      '@swc/core-linux-ppc64-gnu': 1.15.33
+      '@swc/core-linux-s390x-gnu': 1.15.33
+      '@swc/core-linux-x64-gnu': 1.15.33
+      '@swc/core-linux-x64-musl': 1.15.33
+      '@swc/core-win32-arm64-msvc': 1.15.33
+      '@swc/core-win32-ia32-msvc': 1.15.33
+      '@swc/core-win32-x64-msvc': 1.15.33
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/jest@0.2.39(@swc/core@1.15.33)':
+    dependencies:
+      '@jest/create-cache-key-function': 30.4.1
+      '@swc/core': 1.15.33
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.3.1
+
+  '@swc/types@0.1.26':
+    dependencies:
+      '@swc/counter': 0.1.3
+
+  '@total-typescript/shoehorn@0.1.2': {}
 
   '@turbo/darwin-64@2.9.14':
     optional: true
@@ -315,34 +3603,1329 @@ snapshots:
   '@turbo/windows-arm64@2.9.14':
     optional: true
 
-  esbuild@0.25.12:
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@30.0.0':
+    dependencies:
+      expect: 30.4.1
+      pretty-format: 30.4.1
+
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@types/retry@0.12.0': {}
+
+  '@types/stack-utils@2.0.3': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260522.1':
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260522.1
+
+  '@ungap/structured-clone@1.3.1': {}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    optional: true
+
+  agent-base@7.1.4: {}
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  babel-jest@30.4.1(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 30.4.1
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 7.0.1
+      babel-preset-jest: 30.4.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-istanbul@7.0.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-instrument: 6.0.3
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-jest-hoist@30.4.0:
+    dependencies:
+      '@types/babel__core': 7.20.5
+
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
+
+  babel-preset-jest@30.4.0(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      babel-plugin-jest-hoist: 30.4.0
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.32: {}
+
+  bignumber.js@9.3.1: {}
+
+  bowser@2.14.1: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.361
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  buffer-from@1.1.2: {}
+
+  callsites@3.1.0: {}
+
+  camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001793: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
+  ci-info@4.4.0: {}
+
+  cjs-module-lexer@2.2.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.3: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  data-uri-to-buffer@4.0.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  dedent@1.7.2: {}
+
+  deepmerge@4.3.1: {}
+
+  detect-newline@3.1.0: {}
+
+  diff@8.0.4: {}
+
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  electron-to-chromium@1.5.361: {}
+
+  emittery@0.13.1: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@2.0.0: {}
+
+  esprima@4.0.1: {}
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  exit-x@0.2.2: {}
+
+  expect@30.4.1:
+    dependencies:
+      '@jest/expect-utils': 30.4.1
+      '@jest/get-type': 30.1.0
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+
+  extend@3.0.2: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
+
+  get-package-type@0.1.0: {}
+
+  get-stream@6.0.1: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  highlight.js@10.7.3: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.0
+
+  html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  human-signals@2.1.0: {}
+
+  ignore@7.0.5: {}
+
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
+  imurmurhash@0.1.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-fn@2.1.0: {}
+
+  is-stream@2.0.1: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.3
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jest-changed-files@30.4.1:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 30.4.1
+      p-limit: 3.1.0
+
+  jest-circus@30.4.2:
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.2
+      is-generator-fn: 2.1.0
+      jest-each: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      p-limit: 3.1.0
+      pretty-format: 30.4.1
+      pure-rand: 7.0.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@30.4.2(@types/node@25.9.1):
+    dependencies:
+      '@jest/core': 30.4.2
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.4.2(@types/node@25.9.1)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-config@30.4.2(@types/node@24.12.4):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.12.4
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.4.2(@types/node@25.9.1):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@30.4.1:
+    dependencies:
+      '@jest/diff-sequences': 30.4.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.4.1
+
+  jest-docblock@30.4.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.4.1
+      chalk: 4.1.2
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
+
+  jest-environment-node@30.4.1:
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+
+  jest-haste-map@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
+      picomatch: 4.0.4
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  jest-leak-detector@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      pretty-format: 30.4.1
+
+  jest-matcher-utils@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      jest-diff: 30.4.1
+      pretty-format: 30.4.1
+
+  jest-message-util@30.4.1:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@jest/types': 30.4.1
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-util: 30.4.1
+      picomatch: 4.0.4
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      jest-util: 30.4.1
+
+  jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
+    optionalDependencies:
+      jest-resolve: 30.4.1
+
+  jest-regex-util@30.4.0: {}
+
+  jest-resolve-dependencies@30.4.2:
+    dependencies:
+      jest-regex-util: 30.4.0
+      jest-snapshot: 30.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@30.4.1:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.4.1
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.4.1)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      slash: 3.0.0
+      unrs-resolver: 1.12.2
+
+  jest-runner@30.4.2:
+    dependencies:
+      '@jest/console': 30.4.1
+      '@jest/environment': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      chalk: 4.1.2
+      emittery: 0.13.1
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-haste-map: 30.4.1
+      jest-leak-detector: 30.4.1
+      jest-message-util: 30.4.1
+      jest-resolve: 30.4.1
+      jest-runtime: 30.4.2
+      jest-util: 30.4.1
+      jest-watcher: 30.4.1
+      jest-worker: 30.4.1
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@30.4.2:
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/globals': 30.4.1
+      '@jest/source-map': 30.0.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      chalk: 4.1.2
+      cjs-module-lexer: 2.2.0
+      collect-v8-coverage: 1.0.3
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@30.4.1:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+      '@jest/expect-utils': 30.4.1
+      '@jest/get-type': 30.1.0
+      '@jest/snapshot-utils': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      expect: 30.4.1
+      graceful-fs: 4.2.11
+      jest-diff: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
+      semver: 7.8.1
+      synckit: 0.11.12
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-util@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      graceful-fs: 4.2.11
+      picomatch: 4.0.4
+
+  jest-validate@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.4.1
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      leven: 3.1.0
+      pretty-format: 30.4.1
+
+  jest-watcher@30.4.1:
+    dependencies:
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.12.4
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 30.4.1
+      string-length: 4.0.2
+
+  jest-worker@30.4.1:
+    dependencies:
+      '@types/node': 24.12.4
+      '@ungap/structured-clone': 1.3.1
+      jest-util: 30.4.1
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest@30.4.2(@types/node@25.9.1):
+    dependencies:
+      '@jest/core': 30.4.2
+      '@jest/types': 30.4.1
+      import-local: 3.2.0
+      jest-cli: 30.4.2(@types/node@25.9.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  jsesc@3.1.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
+  json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  koffi@2.16.2:
+    optional: true
+
+  leven@3.1.0: {}
+
+  lines-and-columns@1.2.4: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  long@5.3.2: {}
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@11.5.0: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
+
+  marked@15.0.12: {}
+
+  merge-stream@2.0.0: {}
+
+  mimic-fn@2.1.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
+
+  ms@2.1.3: {}
+
+  napi-postinstall@0.3.4: {}
+
+  natural-compare@1.4.0: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  node-int64@0.4.0: {}
+
+  node-releases@2.0.46: {}
+
+  normalize-path@3.0.0: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  openai@6.26.0(ws@8.21.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.4.3
+
+  oxfmt@0.51.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.51.0
+      '@oxfmt/binding-android-arm64': 0.51.0
+      '@oxfmt/binding-darwin-arm64': 0.51.0
+      '@oxfmt/binding-darwin-x64': 0.51.0
+      '@oxfmt/binding-freebsd-x64': 0.51.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.51.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.51.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.51.0
+      '@oxfmt/binding-linux-arm64-musl': 0.51.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.51.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.51.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.51.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.51.0
+      '@oxfmt/binding-linux-x64-gnu': 0.51.0
+      '@oxfmt/binding-linux-x64-musl': 0.51.0
+      '@oxfmt/binding-openharmony-arm64': 0.51.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.51.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.51.0
+      '@oxfmt/binding-win32-x64-msvc': 0.51.0
+
+  oxlint@1.66.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.66.0
+      '@oxlint/binding-android-arm64': 1.66.0
+      '@oxlint/binding-darwin-arm64': 1.66.0
+      '@oxlint/binding-darwin-x64': 1.66.0
+      '@oxlint/binding-freebsd-x64': 1.66.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.66.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.66.0
+      '@oxlint/binding-linux-arm64-gnu': 1.66.0
+      '@oxlint/binding-linux-arm64-musl': 1.66.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.66.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.66.0
+      '@oxlint/binding-linux-riscv64-musl': 1.66.0
+      '@oxlint/binding-linux-s390x-gnu': 1.66.0
+      '@oxlint/binding-linux-x64-gnu': 1.66.0
+      '@oxlint/binding-linux-x64-musl': 1.66.0
+      '@oxlint/binding-openharmony-arm64': 1.66.0
+      '@oxlint/binding-win32-arm64-msvc': 1.66.0
+      '@oxlint/binding-win32-ia32-msvc': 1.66.0
+      '@oxlint/binding-win32-x64-msvc': 1.66.0
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-try@2.2.0: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  partial-json@0.1.7: {}
+
+  path-exists@4.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.0
+      minipass: 7.1.3
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pirates@4.0.7: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
+
+  pretty-format@30.4.1:
+    dependencies:
+      '@jest/schemas': 30.4.1
+      ansi-styles: 5.2.0
+      react-is-18: react-is@18.3.1
+      react-is-19: react-is@19.2.6
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  protobufjs@7.6.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 24.12.4
+      long: 5.3.2
+
+  pure-rand@7.0.1: {}
+
+  react-is@18.3.1: {}
+
+  react-is@19.2.6: {}
+
+  require-directory@2.1.1: {}
+
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
+  resolve-from@5.0.0: {}
+
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
+
+  safe-buffer@5.2.1: {}
+
+  semver@6.3.1: {}
+
+  semver@7.8.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
+
+  slash@3.0.0: {}
+
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-bom@4.0.0: {}
+
+  strip-final-newline@2.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  strnum@2.3.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
+
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 7.2.3
+      minimatch: 3.1.5
+
+  tinypool@2.1.0: {}
+
+  tmpl@1.0.5: {}
+
+  ts-algebra@2.0.0: {}
+
+  tslib@2.8.1: {}
 
   turbo@2.9.14:
     optionalDependencies:
@@ -352,3 +4935,113 @@ snapshots:
       '@turbo/linux-arm64': 2.9.14
       '@turbo/windows-64': 2.9.14
       '@turbo/windows-arm64': 2.9.14
+
+  type-detect@4.0.8: {}
+
+  type-fest@0.21.3: {}
+
+  typebox@1.1.38: {}
+
+  undici-types@7.16.0: {}
+
+  undici-types@7.24.6: {}
+
+  undici@8.3.0: {}
+
+  unrs-resolver@1.12.2:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.12.2
+      '@unrs/resolver-binding-android-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-x64': 1.12.2
+      '@unrs/resolver-binding-freebsd-x64': 1.12.2
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-musl': 1.12.2
+      '@unrs/resolver-binding-openharmony-arm64': 1.12.2
+      '@unrs/resolver-binding-wasm32-wasi': 1.12.2
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
+  web-streams-polyfill@3.3.3: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+
+  ws@8.21.0: {}
+
+  xml-naming@0.1.0: {}
+
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/shared/stow/pi/.pi/agent/turbo.json
+++ b/shared/stow/pi/.pi/agent/turbo.json
@@ -1,6 +1,22 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "tasks": {
+    "format": {
+      "cache": false
+    },
+    "format:check": {
+      "outputs": []
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["typecheck"],
+      "outputs": ["coverage/**"]
+    },
+    "typecheck": {
+      "outputs": []
+    },
     "validate": {
       "inputs": [
         "$TURBO_DEFAULT$",


### PR DESCRIPTION
## Summary
- add oxfmt, oxlint, tsgo, and swc/jest tooling for Pi extensions
- add strict TypeScript config and a shoehorn-backed Jest smoke test
- wire root Turborepo scripts for format, lint, typecheck, test, and validate
- migrate Pi extension imports to @earendil-works packages and fix strict type/lint issues

## Validation
- pnpm --dir shared/stow/pi/.pi/agent run validate
- pi --no-extensions -e extensions/... --list-models
- JSON-mode smoke tests for /repo, /mcp, and /peb-plan /Users/brandon/.dotfiles
- subagent review: no blocking findings