### PR TITLE
feat(picastle): explain planner skipped and blocked candidates

### DIFF
--- a/pi/picastle/README.md
+++ b/pi/picastle/README.md
@@ -59,8 +59,14 @@ Runtime files are outside the target repo:
 ```txt
 ~/.cache/picastle/<safe-repo-path>/
   logs/
+    picastle-planner-<iteration>-audit.json
   worktrees/
 ```
+
+Planner audits record selected and skipped candidate issues with categories such
+as `existing_pr`, `dependency`, `overlap_risk`, `missing_context`, and
+`policy_status`. Console output also summarizes those reasons so an empty plan is
+never just `issues: []` without explaining what Picastle considered.
 
 Implementer worktrees may contain untracked `.picastle/pending-*.jsonl` manifests.
 The host fan-in script applies those to Pebbles after each iteration.

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -315,20 +315,22 @@ function loadCandidateIssues(): unknown[] {
 function readIssues(command: string): unknown[] {
   const result = run(command, repoRoot, { allowFailure: true });
   if (result.status !== 0) {
-    console.warn(`  ⚠ peb issue query failed: ${result.stderr || result.stdout}`);
-    return [];
+    throw new Error(`Pebbles issue query failed: ${result.stderr || result.stdout}`);
   }
-  return JSON.parse(result.stdout || "[]");
+  return parseJsonArray(result.stdout, "Pebbles issue query result");
 }
 
 function parseJsonArray(input: string, description: string): unknown[] {
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(input || "[]");
-    if (Array.isArray(parsed)) return parsed;
+    parsed = JSON.parse(input);
   } catch (error) {
-    console.warn(`  ⚠ failed to parse ${description}: ${formatError(error)}`);
+    throw new Error(`Failed to parse ${description}: ${formatError(error)}`);
   }
-  return [];
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${description} must be a JSON array`);
+  }
+  return parsed;
 }
 
 async function implementIssue(
@@ -822,7 +824,7 @@ async function runPiAgent(args: {
 }
 
 function ensureIssueWorktree(issue: PlannedIssue): string {
-  const branch = normalizeBranch(issue.branch, issue.id, issue.title);
+  const branch = normalizeBranch(issue.branch, issue.id);
   const worktreeName = branch.replace(/^picastle\//, "").replace(/[^a-zA-Z0-9._-]/g, "-");
   const worktreePath = join(worktreesDir, worktreeName);
 

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -20,6 +20,7 @@ import {
 import {
   formatPlannerBlockedSummary,
   normalizeBranch,
+  parsePlannerContext,
   parsePlannerPlan,
   type PlannedIssue,
   type PlannerDecision,
@@ -235,13 +236,16 @@ function extractIssueIdFromBranch(branch: string): string | undefined {
 
 async function planIssues(iteration: number): Promise<PlannerDecision> {
   const candidates = loadCandidateIssues();
-  const issuesJson = JSON.stringify(candidates);
 
   const openPrsJson = run(
     `gh pr list --state open --json number,headRefName,url --jq '[.[] | {number, headRefName, url}]'`,
     repoRoot,
   ).stdout;
   const openPrs = parseJsonArray(openPrsJson, "open GitHub PR list");
+  // Fail closed before giving malformed context to the planner or writing an audit
+  // artifact that would imply the context was trustworthy.
+  parsePlannerContext({ candidates, openPrs });
+  const issuesJson = JSON.stringify(candidates);
 
   const prompt = renderPrompt("plan-prompt.md", {
     ISSUES_JSON: issuesJson,

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -17,7 +17,14 @@ import {
   SessionManager,
 } from "@earendil-works/pi-coding-agent";
 
-type PlannedIssue = { id: string; title: string; branch: string };
+import {
+  formatPlannerBlockedSummary,
+  normalizeBranch,
+  parsePlannerPlan,
+  type PlannedIssue,
+  type PlannerDecision,
+} from "./planner-output.mjs";
+
 type CompletedIssue = PlannedIssue & { worktreePath: string };
 type ReviewStatus = "approved" | "changes_requested" | "blocked";
 type ReviewFinding = {
@@ -117,7 +124,9 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     }
   }
 
-  const issues = await planIssues(iteration);
+  const plan = await planIssues(iteration);
+  const issues = plan.issues;
+  for (const line of formatPlannerBlockedSummary(plan)) console.log(line);
   if (issues.length === 0) {
     console.log("No unblocked issues to work on. Exiting.");
     break;
@@ -224,7 +233,7 @@ function extractIssueIdFromBranch(branch: string): string | undefined {
   return branch.match(/^picastle\/([a-z0-9_]+-[a-z0-9]{3,})-/)?.[1];
 }
 
-async function planIssues(iteration: number): Promise<PlannedIssue[]> {
+async function planIssues(iteration: number): Promise<PlannerDecision> {
   const candidates = loadCandidateIssues();
   const issuesJson = JSON.stringify(candidates);
 
@@ -232,10 +241,11 @@ async function planIssues(iteration: number): Promise<PlannedIssue[]> {
     `gh pr list --state open --json number,headRefName,url --jq '[.[] | {number, headRefName, url}]'`,
     repoRoot,
   ).stdout;
+  const openPrs = parseJsonArray(openPrsJson, "open GitHub PR list");
 
   const prompt = renderPrompt("plan-prompt.md", {
     ISSUES_JSON: issuesJson,
-    OPEN_PRS_JSON: openPrsJson.trim() || "[]",
+    OPEN_PRS_JSON: JSON.stringify(openPrs),
     ISSUE_LABEL: ISSUE_LABEL || "<none>",
     ISSUE_STATUS,
     POLICY_READY_LABEL: queuePolicy.policyReadyLabel ?? "<none>",
@@ -251,28 +261,21 @@ async function planIssues(iteration: number): Promise<PlannedIssue[]> {
     logFile: join(logsDir, `picastle-planner-${iteration}.log`),
   });
 
-  const match = stdout.match(/<plan>([\s\S]*?)<\/plan>/);
-  if (!match) {
-    throw new Error(`Planner did not produce a <plan> block. See ${join(logsDir, `picastle-planner-${iteration}.log`)}`);
-  }
-
-  const parsed = JSON.parse(match[1]!);
-  if (!parsed || !Array.isArray(parsed.issues)) {
-    throw new Error("Planner <plan> JSON must contain an issues array");
-  }
-
-  const planned = parsed.issues.map((issue: Partial<PlannedIssue>) => {
-    if (!issue.id || !issue.title || !issue.branch) {
-      throw new Error(`Invalid planned issue: ${JSON.stringify(issue)}`);
+  let plan: PlannerDecision;
+  try {
+    plan = parsePlannerPlan(stdout, { candidates, openPrs, maxIssues: MAX_ISSUES });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Planner did not produce a <plan> block") {
+      throw new Error(`Planner did not produce a <plan> block. See ${join(logsDir, `picastle-planner-${iteration}.log`)}`);
     }
-    return {
-      id: String(issue.id),
-      title: String(issue.title),
-      branch: normalizeBranch(String(issue.branch), String(issue.id), String(issue.title)),
-    };
-  });
+    throw error;
+  }
 
-  return MAX_ISSUES > 0 ? planned.slice(0, MAX_ISSUES) : planned;
+  writeFileSync(
+    join(logsDir, `picastle-planner-${iteration}-audit.json`),
+    JSON.stringify({ iteration, generatedAt: new Date().toISOString(), candidates, openPrs, ...plan }, null, 2) + "\n",
+  );
+  return plan;
 }
 
 function loadCandidateIssues(): unknown[] {
@@ -316,6 +319,16 @@ function readIssues(command: string): unknown[] {
     return [];
   }
   return JSON.parse(result.stdout || "[]");
+}
+
+function parseJsonArray(input: string, description: string): unknown[] {
+  try {
+    const parsed = JSON.parse(input || "[]");
+    if (Array.isArray(parsed)) return parsed;
+  } catch (error) {
+    console.warn(`  ⚠ failed to parse ${description}: ${formatError(error)}`);
+  }
+  return [];
 }
 
 async function implementIssue(
@@ -901,21 +914,6 @@ function deriveQueuePolicy(policy: PebblesPolicy | undefined): QueuePolicy {
 
 function normalizePolicyStatus(value: string): string {
   return value.trim().toLowerCase().replace(/-/g, "_");
-}
-
-function normalizeBranch(branch: string, id: string, title: string): string {
-  if (branch.startsWith("picastle/")) return branch;
-  if (branch.startsWith("sandcastle/")) return branch.replace(/^sandcastle\//, "picastle/");
-  return `picastle/${id}-${slugify(title)}`;
-}
-
-function slugify(input: string): string {
-  return input
-    .toLowerCase()
-    .replace(/^[a-z]+\([^)]+\):\s*/, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 48) || "issue";
 }
 
 function prTitle(issue: PlannedIssue): string {

--- a/pi/picastle/package.json
+++ b/pi/picastle/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "typecheck": "tsc main.mts --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck",
+    "test": "tsx scripts/planner-output.test.mts",
     "prep": "bash scripts/prep.sh",
     "start": "tsx main.mts"
   },

--- a/pi/picastle/planner-output.mts
+++ b/pi/picastle/planner-output.mts
@@ -23,12 +23,12 @@ export type PlannerDecision = {
   hasSyntheticExplanations: boolean;
 };
 
-type Candidate = Record<string, unknown>;
-type OpenPr = { number?: unknown; headRefName?: unknown; url?: unknown };
+type CandidateInfo = { id: string; title: string };
+type OpenPr = { number?: number | string; headRefName: string; url?: string };
 
 export function parsePlannerPlan(
   stdout: string,
-  options: { candidates: unknown[]; openPrs: OpenPr[]; maxIssues?: number },
+  options: { candidates: unknown[]; openPrs: unknown[]; maxIssues?: number },
 ): PlannerDecision {
   const match = stdout.match(/<plan>([\s\S]*?)<\/plan>/);
   if (!match) throw new Error("Planner did not produce a <plan> block");
@@ -38,8 +38,9 @@ export function parsePlannerPlan(
     throw new Error("Planner <plan> JSON must contain an issues array");
   }
 
-  const candidates = options.candidates.map(candidateInfo).filter((candidate) => candidate.id);
+  const candidates = options.candidates.map(candidateInfo);
   const candidateById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+  const openPrs = options.openPrs.map(openPrInfo);
 
   const seenPlannedIds = new Set<string>();
   const planned = parsed.issues.map((raw: unknown) => {
@@ -65,7 +66,7 @@ export function parsePlannerPlan(
     return {
       id,
       title,
-      branch: normalizeBranch(branch, id, title),
+      branch: normalizeBranch(branch, id),
     };
   });
   const issues = options.maxIssues && options.maxIssues > 0 ? planned.slice(0, options.maxIssues) : planned;
@@ -74,8 +75,13 @@ export function parsePlannerPlan(
 
   let hasSyntheticExplanations = planned.length !== issues.length;
   const skippedById = new Map<string, PlannerSkippedIssue>();
+  const seenSkippedIds = new Set<string>();
   for (const raw of extractSkippedItems(parsed)) {
     const skipped = parseSkippedItem(raw, candidateById);
+    if (seenSkippedIds.has(skipped.id)) {
+      throw new Error(`Planner returned duplicate skipped issue id: ${skipped.id}`);
+    }
+    seenSkippedIds.add(skipped.id);
     if (!candidateById.has(skipped.id)) {
       throw new Error(`Planner returned skipped issue id not present in candidates: ${skipped.id}`);
     }
@@ -97,7 +103,7 @@ export function parsePlannerPlan(
 
   for (const candidate of candidates) {
     if (plannedIds.has(candidate.id) || skippedById.has(candidate.id)) continue;
-    const openPr = findOpenPrForIssue(candidate.id, options.openPrs);
+    const openPr = findOpenPrForIssue(candidate.id, openPrs);
     skippedById.set(candidate.id, openPr ? existingPrSkip(candidate, openPr) : unexplainedSkip(candidate));
     hasSyntheticExplanations = true;
   }
@@ -146,7 +152,7 @@ export function formatPlannerBlockedSummary(decision: PlannerDecision): string[]
   return lines;
 }
 
-export function normalizeBranch(branch: string, id: string, _title: string): string {
+export function normalizeBranch(branch: string, id: string): string {
   let normalized: string;
   if (branch.startsWith("picastle/")) {
     normalized = branch;
@@ -182,7 +188,7 @@ function extractSkippedItems(parsed: Record<string, unknown>): unknown[] {
 
 function parseSkippedItem(
   raw: unknown,
-  candidateById: Map<string, { id: string; title: string }>,
+  candidateById: Map<string, CandidateInfo>,
 ): PlannerSkippedIssue {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     throw new Error(`Invalid skipped issue: ${JSON.stringify(raw)}`);
@@ -209,11 +215,43 @@ function parseSkippedItem(
   };
 }
 
-function candidateInfo(candidate: unknown): { id: string; title: string } {
-  if (!candidate || typeof candidate !== "object") return { id: "", title: "" };
-  const item = candidate as Candidate;
-  const id = stringField(item.id);
-  return { id, title: stringField(item.title) || id };
+function candidateInfo(candidate: unknown, index: number): CandidateInfo {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    throw new Error(`Invalid candidate issue at index ${index}: ${JSON.stringify(candidate)}`);
+  }
+  const item = candidate as Record<string, unknown>;
+  if (typeof item.id !== "string" || item.id.length === 0) {
+    throw new Error(`Invalid candidate issue id at index ${index}: expected a non-empty string`);
+  }
+  if (item.title !== undefined && item.title !== null && typeof item.title !== "string") {
+    throw new Error(`Invalid candidate issue title for ${item.id}: expected a string when present`);
+  }
+  const title = typeof item.title === "string" && item.title ? item.title : item.id;
+  return { id: item.id, title };
+}
+
+function openPrInfo(openPr: unknown, index: number): OpenPr {
+  if (!openPr || typeof openPr !== "object" || Array.isArray(openPr)) {
+    throw new Error(`Invalid open PR record at index ${index}: ${JSON.stringify(openPr)}`);
+  }
+  const item = openPr as Record<string, unknown>;
+  const headRefName = item.headRefName;
+  const number = item.number;
+  const url = item.url;
+  if (typeof headRefName !== "string" || headRefName.length === 0) {
+    throw new Error(`Invalid open PR headRefName at index ${index}: expected a non-empty string`);
+  }
+  if (number !== undefined && typeof number !== "number" && typeof number !== "string") {
+    throw new Error(`Invalid open PR number for ${headRefName}: expected a number or string when present`);
+  }
+  if (url !== undefined && url !== null && typeof url !== "string") {
+    throw new Error(`Invalid open PR url for ${headRefName}: expected a string when present`);
+  }
+
+  const result: OpenPr = { headRefName };
+  if (typeof number === "number" || typeof number === "string") result.number = number;
+  if (typeof url === "string") result.url = url;
+  return result;
 }
 
 function existingPrSkip(candidate: { id: string; title: string }, pr: OpenPr): PlannerSkippedIssue {

--- a/pi/picastle/planner-output.mts
+++ b/pi/picastle/planner-output.mts
@@ -23,8 +23,18 @@ export type PlannerDecision = {
   hasSyntheticExplanations: boolean;
 };
 
-type CandidateInfo = { id: string; title: string };
-type OpenPr = { number?: number | string; headRefName: string; url?: string };
+export type PlannerCandidateInfo = { id: string; title: string };
+export type PlannerOpenPr = { number?: number | string; headRefName: string; url?: string };
+
+export function parsePlannerContext(options: { candidates: unknown[]; openPrs: unknown[] }): {
+  candidates: PlannerCandidateInfo[];
+  openPrs: PlannerOpenPr[];
+} {
+  return {
+    candidates: options.candidates.map(candidateInfo),
+    openPrs: options.openPrs.map(openPrInfo),
+  };
+}
 
 export function parsePlannerPlan(
   stdout: string,
@@ -38,9 +48,8 @@ export function parsePlannerPlan(
     throw new Error("Planner <plan> JSON must contain an issues array");
   }
 
-  const candidates = options.candidates.map(candidateInfo);
+  const { candidates, openPrs } = parsePlannerContext(options);
   const candidateById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
-  const openPrs = options.openPrs.map(openPrInfo);
 
   const seenPlannedIds = new Set<string>();
   const planned = parsed.issues.map((raw: unknown) => {
@@ -188,7 +197,7 @@ function extractSkippedItems(parsed: Record<string, unknown>): unknown[] {
 
 function parseSkippedItem(
   raw: unknown,
-  candidateById: Map<string, CandidateInfo>,
+  candidateById: Map<string, PlannerCandidateInfo>,
 ): PlannerSkippedIssue {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     throw new Error(`Invalid skipped issue: ${JSON.stringify(raw)}`);
@@ -215,7 +224,7 @@ function parseSkippedItem(
   };
 }
 
-function candidateInfo(candidate: unknown, index: number): CandidateInfo {
+function candidateInfo(candidate: unknown, index: number): PlannerCandidateInfo {
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
     throw new Error(`Invalid candidate issue at index ${index}: ${JSON.stringify(candidate)}`);
   }
@@ -230,7 +239,7 @@ function candidateInfo(candidate: unknown, index: number): CandidateInfo {
   return { id: item.id, title };
 }
 
-function openPrInfo(openPr: unknown, index: number): OpenPr {
+function openPrInfo(openPr: unknown, index: number): PlannerOpenPr {
   if (!openPr || typeof openPr !== "object" || Array.isArray(openPr)) {
     throw new Error(`Invalid open PR record at index ${index}: ${JSON.stringify(openPr)}`);
   }
@@ -248,13 +257,13 @@ function openPrInfo(openPr: unknown, index: number): OpenPr {
     throw new Error(`Invalid open PR url for ${headRefName}: expected a string when present`);
   }
 
-  const result: OpenPr = { headRefName };
+  const result: PlannerOpenPr = { headRefName };
   if (typeof number === "number" || typeof number === "string") result.number = number;
   if (typeof url === "string") result.url = url;
   return result;
 }
 
-function existingPrSkip(candidate: { id: string; title: string }, pr: OpenPr): PlannerSkippedIssue {
+function existingPrSkip(candidate: { id: string; title: string }, pr: PlannerOpenPr): PlannerSkippedIssue {
   const number = stringField(pr.number);
   const url = stringField(pr.url);
   const head = stringField(pr.headRefName);
@@ -278,7 +287,7 @@ function unexplainedSkip(candidate: { id: string; title: string }): PlannerSkipp
   };
 }
 
-function findOpenPrForIssue(id: string, openPrs: OpenPr[]): OpenPr | undefined {
+function findOpenPrForIssue(id: string, openPrs: PlannerOpenPr[]): PlannerOpenPr | undefined {
   const escaped = escapeRegExp(id);
   const branchPattern = new RegExp(`^(?:picastle|sandcastle)/${escaped}-.+`);
   return openPrs.find((pr) => branchPattern.test(stringField(pr.headRefName)));

--- a/pi/picastle/planner-output.mts
+++ b/pi/picastle/planner-output.mts
@@ -1,0 +1,243 @@
+export type PlannedIssue = { id: string; title: string; branch: string };
+
+export type PlannerSkipCategory =
+  | "existing_pr"
+  | "dependency"
+  | "overlap_risk"
+  | "missing_context"
+  | "policy_status"
+  | "other";
+
+export type PlannerSkippedIssue = {
+  id: string;
+  title: string;
+  category: PlannerSkipCategory;
+  reason: string;
+  blockers: string[];
+};
+
+export type PlannerDecision = {
+  issues: PlannedIssue[];
+  skipped: PlannerSkippedIssue[];
+  consideredCount: number;
+  hasSyntheticExplanations: boolean;
+};
+
+type Candidate = Record<string, unknown>;
+type OpenPr = { number?: unknown; headRefName?: unknown; url?: unknown };
+
+export function parsePlannerPlan(
+  stdout: string,
+  options: { candidates: unknown[]; openPrs: OpenPr[]; maxIssues?: number },
+): PlannerDecision {
+  const match = stdout.match(/<plan>([\s\S]*?)<\/plan>/);
+  if (!match) throw new Error("Planner did not produce a <plan> block");
+
+  const parsed = JSON.parse(match[1]!);
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.issues)) {
+    throw new Error("Planner <plan> JSON must contain an issues array");
+  }
+
+  const candidates = options.candidates.map(candidateInfo).filter((candidate) => candidate.id);
+  const candidateById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+
+  const planned = parsed.issues.map((issue: Partial<PlannedIssue>) => {
+    if (!issue.id || !issue.title || !issue.branch) {
+      throw new Error(`Invalid planned issue: ${JSON.stringify(issue)}`);
+    }
+    return {
+      id: String(issue.id),
+      title: String(issue.title),
+      branch: normalizeBranch(String(issue.branch), String(issue.id), String(issue.title)),
+    };
+  });
+  const issues = options.maxIssues && options.maxIssues > 0 ? planned.slice(0, options.maxIssues) : planned;
+  const plannedIds = new Set(issues.map((issue) => issue.id));
+
+  let hasSyntheticExplanations = planned.length !== issues.length;
+  const skippedById = new Map<string, PlannerSkippedIssue>();
+  for (const raw of extractSkippedItems(parsed)) {
+    const skipped = parseSkippedItem(raw, candidateById);
+    if (!skipped || plannedIds.has(skipped.id)) continue;
+    skippedById.set(skipped.id, skipped);
+  }
+
+  for (const issue of planned.slice(issues.length)) {
+    skippedById.set(issue.id, {
+      id: issue.id,
+      title: issue.title,
+      category: "policy_status",
+      reason: `Selected by planner but skipped by PICASTLE_MAX_ISSUES=${options.maxIssues}.`,
+      blockers: [],
+    });
+  }
+
+  for (const candidate of candidates) {
+    if (plannedIds.has(candidate.id) || skippedById.has(candidate.id)) continue;
+    const openPr = findOpenPrForIssue(candidate.id, options.openPrs);
+    skippedById.set(candidate.id, openPr ? existingPrSkip(candidate, openPr) : unexplainedSkip(candidate));
+    hasSyntheticExplanations = true;
+  }
+
+  return {
+    issues,
+    skipped: [...skippedById.values()],
+    consideredCount: candidates.length,
+    hasSyntheticExplanations,
+  };
+}
+
+export function formatPlannerBlockedSummary(decision: PlannerDecision): string[] {
+  const lines: string[] = [];
+  if (decision.consideredCount === 0) {
+    lines.push("Planner considered 0 candidate(s); no issues matched the Picastle queue filters.");
+    return lines;
+  }
+
+  lines.push(
+    `Planner considered ${decision.consideredCount} candidate(s); selected ${decision.issues.length}, skipped ${decision.skipped.length}.`,
+  );
+
+  if (decision.skipped.length === 0) return lines;
+
+  const counts = new Map<PlannerSkipCategory, number>();
+  for (const skipped of decision.skipped) counts.set(skipped.category, (counts.get(skipped.category) ?? 0) + 1);
+  lines.push(
+    `Skipped reasons: ${[...counts.entries()]
+      .map(([category, count]) => `${categoryLabel(category)}: ${count}`)
+      .join(", ")}.`,
+  );
+
+  const maxRows = 12;
+  for (const skipped of decision.skipped.slice(0, maxRows)) {
+    const blockers = skipped.blockers.length > 0 ? ` [blockers: ${skipped.blockers.join(", ")}]` : "";
+    lines.push(`  - ${skipped.id}: ${categoryLabel(skipped.category)} — ${truncateLine(skipped.reason, 160)}${blockers}`);
+  }
+  if (decision.skipped.length > maxRows) {
+    lines.push(`  … ${decision.skipped.length - maxRows} more skipped candidate(s); see planner audit artifact.`);
+  }
+  if (decision.hasSyntheticExplanations) {
+    lines.push("Some skip reasons were synthesized by Picastle because the planner omitted explicit explanations.");
+  }
+
+  return lines;
+}
+
+export function normalizeBranch(branch: string, id: string, title: string): string {
+  if (branch.startsWith("picastle/")) return branch;
+  if (branch.startsWith("sandcastle/")) return branch.replace(/^sandcastle\//, "picastle/");
+  return `picastle/${id}-${slugify(title)}`;
+}
+
+function extractSkippedItems(parsed: Record<string, unknown>): unknown[] {
+  const result: unknown[] = [];
+  for (const key of ["skipped", "blocked", "filtered", "declined"] as const) {
+    const items = parsed[key];
+    if (Array.isArray(items)) result.push(...items);
+  }
+  return result;
+}
+
+function parseSkippedItem(
+  raw: unknown,
+  candidateById: Map<string, { id: string; title: string }>,
+): PlannerSkippedIssue | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const item = raw as Record<string, unknown>;
+  const id = stringField(item.id) || stringField(item.issue_id) || stringField(item.issueId);
+  if (!id) return undefined;
+  const candidate = candidateById.get(id);
+  const title = stringField(item.title) || candidate?.title || id;
+  return {
+    id,
+    title,
+    category: normalizeCategory(
+      stringField(item.category) || stringField(item.reason_category) || stringField(item.reasonCategory) || stringField(item.type),
+    ),
+    reason:
+      stringField(item.reason) ||
+      stringField(item.summary) ||
+      stringField(item.details) ||
+      "Planner skipped this candidate without a detailed reason.",
+    blockers: stringArrayField(item.blockers) ?? stringArrayField(item.blocked_by) ?? stringArrayField(item.blockedBy) ?? [],
+  };
+}
+
+function candidateInfo(candidate: unknown): { id: string; title: string } {
+  if (!candidate || typeof candidate !== "object") return { id: "", title: "" };
+  const item = candidate as Candidate;
+  const id = stringField(item.id);
+  return { id, title: stringField(item.title) || id };
+}
+
+function existingPrSkip(candidate: { id: string; title: string }, pr: OpenPr): PlannerSkippedIssue {
+  const number = stringField(pr.number);
+  const url = stringField(pr.url);
+  const head = stringField(pr.headRefName);
+  const ref = number ? `#${number}` : url || head || "an open PR";
+  return {
+    id: candidate.id,
+    title: candidate.title,
+    category: "existing_pr",
+    reason: `Open PR ${ref} is already in flight for ${candidate.id}.`,
+    blockers: [ref],
+  };
+}
+
+function unexplainedSkip(candidate: { id: string; title: string }): PlannerSkippedIssue {
+  return {
+    id: candidate.id,
+    title: candidate.title,
+    category: "missing_context",
+    reason: "Planner selected no work for this candidate but did not provide an explicit skip reason.",
+    blockers: [],
+  };
+}
+
+function findOpenPrForIssue(id: string, openPrs: OpenPr[]): OpenPr | undefined {
+  const escaped = escapeRegExp(id);
+  const branchPattern = new RegExp(`^(?:picastle|sandcastle)/${escaped}-.+`);
+  return openPrs.find((pr) => branchPattern.test(stringField(pr.headRefName)));
+}
+
+function normalizeCategory(value: string): PlannerSkipCategory {
+  const normalized = value.toLowerCase().replace(/[\s-]+/g, "_");
+  if (["existing_pr", "open_pr", "pr", "in_flight", "already_in_flight"].includes(normalized)) return "existing_pr";
+  if (["dependency", "dependencies", "blocked", "blocked_by", "depends_on"].includes(normalized)) return "dependency";
+  if (["overlap", "overlap_risk", "conflict", "conflict_risk", "file_overlap"].includes(normalized)) return "overlap_risk";
+  if (["missing_context", "needs_context", "insufficient_context", "unknown"].includes(normalized)) return "missing_context";
+  if (["policy", "policy_status", "status", "label", "queue_policy"].includes(normalized)) return "policy_status";
+  return "other";
+}
+
+function categoryLabel(category: PlannerSkipCategory): string {
+  return category.replace(/_/g, " ").replace(/^existing pr$/, "existing PR");
+}
+
+function stringField(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
+function stringArrayField(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map(stringField).filter(Boolean);
+}
+
+function truncateLine(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/^[a-z]+\([^)]+\):\s*/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "issue";
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/pi/picastle/planner-output.mts
+++ b/pi/picastle/planner-output.mts
@@ -70,16 +70,18 @@ export function parsePlannerPlan(
   });
   const issues = options.maxIssues && options.maxIssues > 0 ? planned.slice(0, options.maxIssues) : planned;
   const plannedIds = new Set(issues.map((issue) => issue.id));
+  const allPlannedIds = new Set(planned.map((issue) => issue.id));
 
   let hasSyntheticExplanations = planned.length !== issues.length;
   const skippedById = new Map<string, PlannerSkippedIssue>();
   for (const raw of extractSkippedItems(parsed)) {
     const skipped = parseSkippedItem(raw, candidateById);
-    if (!skipped) continue;
     if (!candidateById.has(skipped.id)) {
       throw new Error(`Planner returned skipped issue id not present in candidates: ${skipped.id}`);
     }
-    if (plannedIds.has(skipped.id)) continue;
+    if (allPlannedIds.has(skipped.id)) {
+      throw new Error(`Planner returned issue id in both issues and skipped: ${skipped.id}`);
+    }
     skippedById.set(skipped.id, skipped);
   }
 
@@ -144,17 +146,36 @@ export function formatPlannerBlockedSummary(decision: PlannerDecision): string[]
   return lines;
 }
 
-export function normalizeBranch(branch: string, id: string, title: string): string {
-  if (branch.startsWith("picastle/")) return branch;
-  if (branch.startsWith("sandcastle/")) return branch.replace(/^sandcastle\//, "picastle/");
-  return `picastle/${id}-${slugify(title)}`;
+export function normalizeBranch(branch: string, id: string, _title: string): string {
+  let normalized: string;
+  if (branch.startsWith("picastle/")) {
+    normalized = branch;
+  } else if (branch.startsWith("sandcastle/")) {
+    normalized = branch.replace(/^sandcastle\//, "picastle/");
+  } else {
+    throw new Error(
+      `Planner branch for ${id} must use picastle/${id}-... (sandcastle/ is also accepted for migration), got ${JSON.stringify(branch)}`,
+    );
+  }
+
+  const pattern = new RegExp(`^picastle/${escapeRegExp(id)}-.+`);
+  if (!pattern.test(normalized)) {
+    throw new Error(
+      `Planner branch for ${id} must normalize to picastle/${id}-..., got ${JSON.stringify(normalized)}`,
+    );
+  }
+  return normalized;
 }
 
 function extractSkippedItems(parsed: Record<string, unknown>): unknown[] {
   const result: unknown[] = [];
   for (const key of ["skipped", "blocked", "filtered", "declined"] as const) {
+    if (!(key in parsed)) continue;
     const items = parsed[key];
-    if (Array.isArray(items)) result.push(...items);
+    if (!Array.isArray(items)) {
+      throw new Error(`Planner <plan> ${key} field must be an array when present`);
+    }
+    result.push(...items);
   }
   return result;
 }
@@ -162,11 +183,15 @@ function extractSkippedItems(parsed: Record<string, unknown>): unknown[] {
 function parseSkippedItem(
   raw: unknown,
   candidateById: Map<string, { id: string; title: string }>,
-): PlannerSkippedIssue | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
+): PlannerSkippedIssue {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`Invalid skipped issue: ${JSON.stringify(raw)}`);
+  }
   const item = raw as Record<string, unknown>;
   const id = stringField(item.id) || stringField(item.issue_id) || stringField(item.issueId);
-  if (!id) return undefined;
+  if (!id) {
+    throw new Error(`Invalid skipped issue: ${JSON.stringify(item)}`);
+  }
   const candidate = candidateById.get(id);
   const title = stringField(item.title) || candidate?.title || id;
   return {
@@ -180,7 +205,7 @@ function parseSkippedItem(
       stringField(item.summary) ||
       stringField(item.details) ||
       "Planner skipped this candidate without a detailed reason.",
-    blockers: stringArrayField(item.blockers) ?? stringArrayField(item.blocked_by) ?? stringArrayField(item.blockedBy) ?? [],
+    blockers: skippedBlockers(item),
   };
 }
 
@@ -221,6 +246,18 @@ function findOpenPrForIssue(id: string, openPrs: OpenPr[]): OpenPr | undefined {
   return openPrs.find((pr) => branchPattern.test(stringField(pr.headRefName)));
 }
 
+function skippedBlockers(item: Record<string, unknown>): string[] {
+  for (const key of ["blockers", "blocked_by", "blockedBy"] as const) {
+    if (!(key in item)) continue;
+    const blockers = stringArrayField(item[key]);
+    if (!blockers) {
+      throw new Error(`Invalid skipped issue blockers for ${stringField(item.id) || "unknown issue"}: must be an array`);
+    }
+    return blockers;
+  }
+  return [];
+}
+
 function normalizeCategory(value: string): PlannerSkipCategory {
   const normalized = value.toLowerCase().replace(/[\s-]+/g, "_");
   if (["existing_pr", "open_pr", "pr", "in_flight", "already_in_flight"].includes(normalized)) return "existing_pr";
@@ -248,15 +285,6 @@ function stringArrayField(value: unknown): string[] | undefined {
 
 function truncateLine(text: string, max: number): string {
   return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
-}
-
-function slugify(input: string): string {
-  return input
-    .toLowerCase()
-    .replace(/^[a-z]+\([^)]+\):\s*/, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 48) || "issue";
 }
 
 function escapeRegExp(value: string): string {

--- a/pi/picastle/planner-output.mts
+++ b/pi/picastle/planner-output.mts
@@ -41,14 +41,31 @@ export function parsePlannerPlan(
   const candidates = options.candidates.map(candidateInfo).filter((candidate) => candidate.id);
   const candidateById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
 
-  const planned = parsed.issues.map((issue: Partial<PlannedIssue>) => {
-    if (!issue.id || !issue.title || !issue.branch) {
+  const seenPlannedIds = new Set<string>();
+  const planned = parsed.issues.map((raw: unknown) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error(`Invalid planned issue: ${JSON.stringify(raw)}`);
+    }
+
+    const issue = raw as Partial<PlannedIssue>;
+    const id = stringField(issue.id);
+    const title = stringField(issue.title);
+    const branch = stringField(issue.branch);
+    if (!id || !title || !branch) {
       throw new Error(`Invalid planned issue: ${JSON.stringify(issue)}`);
     }
+    if (seenPlannedIds.has(id)) {
+      throw new Error(`Planner returned duplicate planned issue id: ${id}`);
+    }
+    if (!candidateById.has(id)) {
+      throw new Error(`Planner returned planned issue id not present in candidates: ${id}`);
+    }
+    seenPlannedIds.add(id);
+
     return {
-      id: String(issue.id),
-      title: String(issue.title),
-      branch: normalizeBranch(String(issue.branch), String(issue.id), String(issue.title)),
+      id,
+      title,
+      branch: normalizeBranch(branch, id, title),
     };
   });
   const issues = options.maxIssues && options.maxIssues > 0 ? planned.slice(0, options.maxIssues) : planned;
@@ -58,7 +75,11 @@ export function parsePlannerPlan(
   const skippedById = new Map<string, PlannerSkippedIssue>();
   for (const raw of extractSkippedItems(parsed)) {
     const skipped = parseSkippedItem(raw, candidateById);
-    if (!skipped || plannedIds.has(skipped.id)) continue;
+    if (!skipped) continue;
+    if (!candidateById.has(skipped.id)) {
+      throw new Error(`Planner returned skipped issue id not present in candidates: ${skipped.id}`);
+    }
+    if (plannedIds.has(skipped.id)) continue;
     skippedById.set(skipped.id, skipped);
   }
 

--- a/pi/picastle/prompts/plan-prompt.md
+++ b/pi/picastle/prompts/plan-prompt.md
@@ -55,16 +55,45 @@ where `{id}` is the pebbles ID and `{slug}` is a short kebab-case title summary.
 
 Output only a JSON object wrapped in `<plan>` tags.
 
+Schema:
+
+```json
+{
+  "issues": [
+    {"id": "repo-srr", "title": "fix(ui): window drag", "branch": "picastle/repo-srr-window-drag"}
+  ],
+  "skipped": [
+    {
+      "id": "repo-abc",
+      "title": "feat(api): blocked example",
+      "category": "existing_pr | dependency | overlap_risk | missing_context | policy_status | other",
+      "reason": "Concise, specific reason this candidate was not planned.",
+      "blockers": ["PR #123", "repo-xyz"]
+    }
+  ]
+}
+```
+
+Rules:
+
+- Include every candidate issue exactly once, either in `issues` or `skipped`.
+- Use `existing_pr` when a `picastle/{id}-*` or `sandcastle/{id}-*` PR is already open.
+- Use `dependency` for explicit or native unresolved dependencies.
+- Use `overlap_risk` when concurrent work is likely to conflict with an open PR or selected issue.
+- Use `missing_context` when the issue cannot be planned safely because the brief lacks enough context.
+- Use `policy_status` when labels/status/policy make it ineligible despite being present in the candidate JSON.
+- Do not output `{"issues": []}` without populated `skipped` explanations unless there were zero candidates.
+
 When at least one issue is unblocked:
 
 <plan>
-{"issues": [{"id": "repo-srr", "title": "fix(ui): window drag", "branch": "picastle/repo-srr-window-drag"}]}
+{"issues": [{"id": "repo-srr", "title": "fix(ui): window drag", "branch": "picastle/repo-srr-window-drag"}], "skipped": [{"id": "repo-abc", "title": "feat(api): blocked example", "category": "overlap_risk", "reason": "Touches the same API module as open PR #123.", "blockers": ["PR #123"]}]}
 </plan>
 
 When every candidate is blocked or filtered:
 
 <plan>
-{"issues": []}
+{"issues": [], "skipped": [{"id": "repo-abc", "title": "feat(api): blocked example", "category": "existing_pr", "reason": "Open PR #123 already uses picastle/repo-abc-api-example.", "blockers": ["PR #123"]}]}
 </plan>
 
 Do not plan blocked issues.

--- a/pi/picastle/scripts/planner-output.test.mts
+++ b/pi/picastle/scripts/planner-output.test.mts
@@ -110,21 +110,82 @@ const candidatesWithThird = [
       ),
     /Invalid planned issue/,
   );
+
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        '<plan>{"issues":[{"id":"repo-abc","title":"fix(auth): stale token","branch":"picastle/repo-def-token"}]}</plan>',
+        { candidates, openPrs: [] },
+      ),
+    /must normalize to picastle\/repo-abc-/,
+  );
+
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        '<plan>{"issues":[{"id":"repo-abc","title":"fix(auth): stale token","branch":"feature/repo-abc-token"}]}</plan>',
+        { candidates, openPrs: [] },
+      ),
+    /must use picastle\/repo-abc-/,
+  );
 }
 
 {
-  const decision = parsePlannerPlan(
-    `<plan>{
-      "issues": [],
-      "skipped": [null, {"title":"missing id","category":"dependency","reason":"no candidate id"}]
-    }</plan>`,
-    { candidates: candidates.slice(0, 1), openPrs: [] },
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        `<plan>{
+          "issues": [],
+          "skipped": [null]
+        }</plan>`,
+        { candidates: candidates.slice(0, 1), openPrs: [] },
+      ),
+    /Invalid skipped issue: null/,
   );
 
-  assert.equal(decision.skipped.length, 1);
-  assert.equal(decision.skipped[0]?.id, "repo-abc");
-  assert.equal(decision.skipped[0]?.category, "missing_context");
-  assert.equal(decision.hasSyntheticExplanations, true);
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        `<plan>{
+          "issues": [],
+          "skipped": [{"title":"missing id","category":"dependency","reason":"no candidate id"}]
+        }</plan>`,
+        { candidates: candidates.slice(0, 1), openPrs: [] },
+      ),
+    /Invalid skipped issue/,
+  );
+
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        '<plan>{"issues":[],"skipped":{"id":"repo-abc","reason":"not an array"}}</plan>',
+        { candidates, openPrs: [] },
+      ),
+    /skipped field must be an array/,
+  );
+
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        '<plan>{"issues":[],"skipped":[{"id":"repo-abc","reason":"bad blockers","blockers":"repo-def"}]}</plan>',
+        { candidates, openPrs: [] },
+      ),
+    /blockers for repo-abc: must be an array/,
+  );
+}
+
+{
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        `<plan>{
+          "issues": [{"id":"repo-abc","title":"fix(auth): stale token","branch":"picastle/repo-abc-token"}],
+          "skipped": [{"id":"repo-abc","title":"fix(auth): stale token","category":"dependency","reason":"also skipped"}]
+        }</plan>`,
+        { candidates, openPrs: [] },
+      ),
+    /in both issues and skipped: repo-abc/,
+  );
 }
 
 {

--- a/pi/picastle/scripts/planner-output.test.mts
+++ b/pi/picastle/scripts/planner-output.test.mts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import {
   formatPlannerBlockedSummary,
+  parsePlannerContext,
   parsePlannerPlan,
 } from "../planner-output.mjs";
 
@@ -13,6 +14,45 @@ const candidatesWithThird = [
   ...candidates,
   { id: "repo-ghi", title: "chore(api): cleanup", status: "ready_for_agent" },
 ];
+
+// planIssues lives in main.mts, whose top-level daemon loop runs on import.
+// Instead of importing it in tests, cover the shared context parser that planIssues
+// calls before rendering the planner prompt or writing the audit artifact.
+{
+  assert.deepEqual(
+    parsePlannerContext({
+      candidates: [{ id: "repo-no-title", status: "ready_for_agent" }],
+      openPrs: [{ number: "42", headRefName: "sandcastle/repo-no-title-fix", url: null }],
+    }),
+    {
+      candidates: [{ id: "repo-no-title", title: "repo-no-title" }],
+      openPrs: [{ number: "42", headRefName: "sandcastle/repo-no-title-fix" }],
+    },
+  );
+
+  assert.throws(
+    () => parsePlannerContext({ candidates: [{ id: "repo-abc", title: 123 }], openPrs: [] }),
+    /Invalid candidate issue title for repo-abc/,
+  );
+
+  assert.throws(
+    () =>
+      parsePlannerContext({
+        candidates,
+        openPrs: [{ number: { value: 42 }, headRefName: "picastle/repo-abc-stale-token" }],
+      }),
+    /Invalid open PR number for picastle\/repo-abc-stale-token/,
+  );
+
+  assert.throws(
+    () =>
+      parsePlannerContext({
+        candidates,
+        openPrs: [{ headRefName: "picastle/repo-abc-stale-token", url: 42 }],
+      }),
+    /Invalid open PR url for picastle\/repo-abc-stale-token/,
+  );
+}
 
 {
   const decision = parsePlannerPlan(

--- a/pi/picastle/scripts/planner-output.test.mts
+++ b/pi/picastle/scripts/planner-output.test.mts
@@ -9,6 +9,10 @@ const candidates = [
   { id: "repo-abc", title: "fix(auth): stale token", status: "ready_for_agent" },
   { id: "repo-def", title: "feat(ui): new panel", status: "ready_for_agent" },
 ];
+const candidatesWithThird = [
+  ...candidates,
+  { id: "repo-ghi", title: "chore(api): cleanup", status: "ready_for_agent" },
+];
 
 {
   const decision = parsePlannerPlan(
@@ -50,6 +54,99 @@ const candidates = [
   assert.equal(decision.skipped.length, 1);
   assert.equal(decision.skipped[0]?.category, "overlap_risk");
   assert.deepEqual(decision.skipped[0]?.blockers, ["PR #42"]);
+}
+
+{
+  assert.throws(
+    () => parsePlannerPlan("no plan here", { candidates, openPrs: [] }),
+    /Planner did not produce a <plan> block/,
+  );
+  assert.throws(
+    () => parsePlannerPlan("<plan>{not json}</plan>", { candidates, openPrs: [] }),
+    SyntaxError,
+  );
+  assert.throws(
+    () => parsePlannerPlan('<plan>{"skipped": []}</plan>', { candidates, openPrs: [] }),
+    /issues array/,
+  );
+}
+
+{
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        `<plan>{"issues":[
+          {"id":"repo-abc","title":"fix(auth): stale token","branch":"picastle/repo-abc-token"},
+          {"id":"repo-abc","title":"fix(auth): stale token again","branch":"picastle/repo-abc-token-again"}
+        ]}</plan>`,
+        { candidates, openPrs: [] },
+      ),
+    /duplicate planned issue id: repo-abc/,
+  );
+
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        '<plan>{"issues":[{"id":"repo-zzz","title":"unknown","branch":"picastle/repo-zzz-unknown"}]}</plan>',
+        { candidates, openPrs: [] },
+      ),
+    /not present in candidates: repo-zzz/,
+  );
+
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        '<plan>{"issues":[],"skipped":[{"id":"repo-zzz","title":"unknown","category":"other","reason":"hallucinated"}]}</plan>',
+        { candidates, openPrs: [] },
+      ),
+    /not present in candidates: repo-zzz/,
+  );
+
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        '<plan>{"issues":[{"id":"repo-abc","title":"fix(auth): stale token"}]}</plan>',
+        { candidates, openPrs: [] },
+      ),
+    /Invalid planned issue/,
+  );
+}
+
+{
+  const decision = parsePlannerPlan(
+    `<plan>{
+      "issues": [],
+      "skipped": [null, {"title":"missing id","category":"dependency","reason":"no candidate id"}]
+    }</plan>`,
+    { candidates: candidates.slice(0, 1), openPrs: [] },
+  );
+
+  assert.equal(decision.skipped.length, 1);
+  assert.equal(decision.skipped[0]?.id, "repo-abc");
+  assert.equal(decision.skipped[0]?.category, "missing_context");
+  assert.equal(decision.hasSyntheticExplanations, true);
+}
+
+{
+  const decision = parsePlannerPlan(
+    `<plan>{
+      "issues": [
+        {"id":"repo-abc","title":"fix(auth): stale token","branch":"picastle/repo-abc-token"},
+        {"id":"repo-def","title":"feat(ui): new panel","branch":"picastle/repo-def-panel"}
+      ],
+      "skipped": [{"id":"repo-ghi","title":"chore(api): cleanup","category":"policy_status","reason":"deferred by policy","blockers":[]}]
+    }</plan>`,
+    { candidates: candidatesWithThird, openPrs: [], maxIssues: 1 },
+  );
+
+  assert.deepEqual(decision.issues, [
+    { id: "repo-abc", title: "fix(auth): stale token", branch: "picastle/repo-abc-token" },
+  ]);
+  assert.equal(decision.skipped.length, 2);
+  assert.equal(decision.skipped.find((issue) => issue.id === "repo-def")?.category, "policy_status");
+  assert.match(decision.skipped.find((issue) => issue.id === "repo-def")?.reason ?? "", /PICASTLE_MAX_ISSUES=1/);
+  assert.equal(decision.skipped.find((issue) => issue.id === "repo-ghi")?.reason, "deferred by policy");
+  assert.equal(decision.hasSyntheticExplanations, true);
 }
 
 console.log("planner-output tests passed");

--- a/pi/picastle/scripts/planner-output.test.mts
+++ b/pi/picastle/scripts/planner-output.test.mts
@@ -172,6 +172,21 @@ const candidatesWithThird = [
       ),
     /blockers for repo-abc: must be an array/,
   );
+
+  assert.throws(
+    () =>
+      parsePlannerPlan(
+        `<plan>{
+          "issues": [],
+          "skipped": [
+            {"id":"repo-abc","reason":"first explanation"},
+            {"id":"repo-abc","reason":"second explanation"}
+          ]
+        }</plan>`,
+        { candidates, openPrs: [] },
+      ),
+    /duplicate skipped issue id: repo-abc/,
+  );
 }
 
 {
@@ -185,6 +200,28 @@ const candidatesWithThird = [
         { candidates, openPrs: [] },
       ),
     /in both issues and skipped: repo-abc/,
+  );
+}
+
+{
+  assert.throws(
+    () => parsePlannerPlan('<plan>{"issues": []}</plan>', { candidates: [null], openPrs: [] }),
+    /Invalid candidate issue at index 0/,
+  );
+
+  assert.throws(
+    () => parsePlannerPlan('<plan>{"issues": []}</plan>', { candidates: [{ title: "missing id" }], openPrs: [] }),
+    /Invalid candidate issue id at index 0/,
+  );
+
+  assert.throws(
+    () => parsePlannerPlan('<plan>{"issues": []}</plan>', { candidates, openPrs: [null] }),
+    /Invalid open PR record at index 0/,
+  );
+
+  assert.throws(
+    () => parsePlannerPlan('<plan>{"issues": []}</plan>', { candidates, openPrs: [{ number: 42, url: "https://github.com/acme/repo/pull/42" }] }),
+    /Invalid open PR headRefName at index 0/,
   );
 }
 

--- a/pi/picastle/scripts/planner-output.test.mts
+++ b/pi/picastle/scripts/planner-output.test.mts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+
+import {
+  formatPlannerBlockedSummary,
+  parsePlannerPlan,
+} from "../planner-output.mjs";
+
+const candidates = [
+  { id: "repo-abc", title: "fix(auth): stale token", status: "ready_for_agent" },
+  { id: "repo-def", title: "feat(ui): new panel", status: "ready_for_agent" },
+];
+
+{
+  const decision = parsePlannerPlan(
+    '<plan>{"issues": []}</plan>',
+    {
+      candidates,
+      openPrs: [{ number: 42, headRefName: "picastle/repo-abc-stale-token", url: "https://github.com/acme/repo/pull/42" }],
+    },
+  );
+
+  assert.equal(decision.issues.length, 0);
+  assert.equal(decision.skipped.length, 2);
+  assert.equal(decision.skipped[0]?.id, "repo-abc");
+  assert.equal(decision.skipped[0]?.category, "existing_pr");
+  assert.match(decision.skipped[0]?.reason ?? "", /#42/);
+  assert.equal(decision.skipped[1]?.id, "repo-def");
+  assert.equal(decision.skipped[1]?.category, "missing_context");
+  assert.equal(decision.hasSyntheticExplanations, true);
+
+  const summary = formatPlannerBlockedSummary(decision).join("\n");
+  assert.match(summary, /Planner considered 2 candidate\(s\); selected 0, skipped 2\./);
+  assert.match(summary, /existing PR: 1/);
+  assert.match(summary, /missing context: 1/);
+  assert.doesNotMatch(summary, /issues: \[\]/);
+}
+
+{
+  const decision = parsePlannerPlan(
+    `<plan>{
+      "issues": [{"id":"repo-def","title":"feat(ui): new panel","branch":"sandcastle/repo-def-panel"}],
+      "blocked": [{"id":"repo-abc","title":"fix(auth): stale token","category":"overlap_risk","reason":"touches auth files in PR #42","blockers":["PR #42"]}]
+    }</plan>`,
+    { candidates, openPrs: [] },
+  );
+
+  assert.deepEqual(decision.issues, [
+    { id: "repo-def", title: "feat(ui): new panel", branch: "picastle/repo-def-panel" },
+  ]);
+  assert.equal(decision.skipped.length, 1);
+  assert.equal(decision.skipped[0]?.category, "overlap_risk");
+  assert.deepEqual(decision.skipped[0]?.blockers, ["PR #42"]);
+}
+
+console.log("planner-output tests passed");


### PR DESCRIPTION
> *This PR was produced by an autonomous Picastle run from the agent brief on pebbles issue dotfiles-7hf.*

## Summary

Implements the Picastle-selected pebbles issue:

- dotfiles-7hf: feat(picastle): explain planner skipped and blocked candidates

Review the original brief with:

```bash
peb --remote 'pi' -R 'dotfiles' show 'dotfiles-7hf'
```

## Verification

Picastle ran the configured verification step for the files changed by this branch before opening the PR.

Closes: dotfiles-7hf
