### PR TITLE
fix(picastle): enforce reviewer agents as truly read-only

### DIFF
--- a/pi/picastle/README.md
+++ b/pi/picastle/README.md
@@ -65,6 +65,12 @@ Runtime files are outside the target repo:
 Implementer worktrees may contain untracked `.picastle/pending-*.jsonl` manifests.
 The host fan-in script applies those to Pebbles after each iteration.
 
+Reviewer agents are granted only read tools plus `review_check`, a restricted
+allowlisted command runner. They do not receive `bash`, `edit`, or `write`.
+`review_check` allows git/Pebbles/GitHub inspection commands, rejects commits,
+pushes, PR creation, Pebbles writes, redirects, and general shell syntax, and
+runs standard build/test checks in a disposable copy of the issue worktree.
+
 ## Useful knobs
 
 - `PICASTLE_CONCURRENCY=3`

--- a/pi/picastle/README.md
+++ b/pi/picastle/README.md
@@ -67,9 +67,11 @@ The host fan-in script applies those to Pebbles after each iteration.
 
 Reviewer agents are granted only read tools plus `review_check`, a restricted
 allowlisted command runner. They do not receive `bash`, `edit`, or `write`.
-`review_check` allows git/Pebbles/GitHub inspection commands, rejects commits,
-pushes, PR creation, Pebbles writes, redirects, and general shell syntax, and
-runs standard build/test checks in a disposable copy of the issue worktree.
+`review_check` allows git/Pebbles/GitHub inspection commands and rejects
+project-code execution (package scripts, test runners, compilers, and build
+tools), commits, pushes, PR creation, Pebbles writes, redirects, and general
+shell syntax. Reviewers record any executable-check validation gap for the
+repair/implementer path instead of running branch-controlled code.
 
 ## Useful knobs
 

--- a/pi/picastle/README.md
+++ b/pi/picastle/README.md
@@ -65,8 +65,8 @@ Runtime files are outside the target repo:
 Implementer worktrees may contain untracked `.picastle/pending-*.jsonl` manifests.
 The host fan-in script applies those to Pebbles after each iteration.
 
-Reviewer agents are granted only read tools plus `review_check`, a restricted
-allowlisted command runner. They do not receive `bash`, `edit`, or `write`, and
+Reviewer agents are granted only `review_check`, a restricted allowlisted
+command runner. They do not receive `bash`, `edit`, or `write`, and
 Picastle disables Pi extension loading for reviewer sessions so reviewed branches
 cannot run project-local extension code during startup.
 `review_check` allows git/Pebbles/GitHub inspection commands and rejects

--- a/pi/picastle/README.md
+++ b/pi/picastle/README.md
@@ -66,7 +66,9 @@ Implementer worktrees may contain untracked `.picastle/pending-*.jsonl` manifest
 The host fan-in script applies those to Pebbles after each iteration.
 
 Reviewer agents are granted only read tools plus `review_check`, a restricted
-allowlisted command runner. They do not receive `bash`, `edit`, or `write`.
+allowlisted command runner. They do not receive `bash`, `edit`, or `write`, and
+Picastle disables Pi extension loading for reviewer sessions so reviewed branches
+cannot run project-local extension code during startup.
 `review_check` allows git/Pebbles/GitHub inspection commands and rejects
 project-code execution (package scripts, test runners, compilers, and build
 tools), commits, pushes, PR creation, Pebbles writes, redirects, and general

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -464,7 +464,7 @@ async function reviewCompletedIssue(
   const stdout = await runPiAgent({
     name: `reviewer-${issue.id}-${pass}`,
     cwd: issue.worktreePath,
-    tools: ["read", "grep", "find", "ls", "review_check"],
+    tools: ["review_check"],
     customTools: [createReviewCheckTool(issue.worktreePath)],
     disableExtensions: true,
     prompt,
@@ -1044,13 +1044,14 @@ function run(
     maxBuffer: 1024 * 1024 * 20,
     env: { ...process.env, ...(opts.env ?? {}) },
   });
-  const status = result.status ?? 1;
+  const status = result.status === null ? 1 : result.status;
   const stdout = typeof result.stdout === "string" ? result.stdout : "";
   const stderr = typeof result.stderr === "string" ? result.stderr : "";
+  const termination = result.status === null ? formatSpawnFailure(result.error, result.signal) : "";
   if (status !== 0 && !opts.allowFailure) {
-    throw new Error(`command failed (${status}): ${command}\n${stdout}${stderr}`);
+    throw new Error(`command failed (${status}): ${command}\n${stdout}${stderr}${termination}`);
   }
-  return { status, stdout, stderr };
+  return { status, stdout, stderr: stderr + termination };
 }
 
 function extractPrRef(output: string): string | undefined {
@@ -1160,6 +1161,11 @@ function append(path: string, text: string): void {
 
 function truncate(text: string, max: number): string {
   return text.length <= max ? text : `${text.slice(0, max)}\n... truncated ...`;
+}
+
+function formatSpawnFailure(error: Error | undefined, signal: NodeJS.Signals | null): string {
+  const details = [signal ? `signal ${signal}` : undefined, error ? error.message : undefined].filter(Boolean).join("; ");
+  return details ? `spawn failed: ${details}` : "spawn failed with unknown termination";
 }
 
 function formatError(error: unknown): string {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -20,8 +20,7 @@ import {
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 
-import { createReviewerResourceLoader } from "./review-session.mts";
-import { createReviewCheckTool } from "./review-tools.mts";
+import { createReviewerAgentTooling, createReviewerResourceLoader } from "./review-session.mts";
 
 type PlannedIssue = { id: string; title: string; branch: string };
 type CompletedIssue = PlannedIssue & { worktreePath: string };
@@ -464,9 +463,7 @@ async function reviewCompletedIssue(
   const stdout = await runPiAgent({
     name: `reviewer-${issue.id}-${pass}`,
     cwd: issue.worktreePath,
-    tools: ["review_check"],
-    customTools: [createReviewCheckTool(issue.worktreePath)],
-    disableExtensions: true,
+    ...createReviewerAgentTooling(issue.worktreePath),
     prompt,
     logFile: join(logsDir, `picastle-${issue.id}-review-${iteration}-${pass}.log`),
   });

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -13,11 +13,14 @@ import { fileURLToPath } from "node:url";
 import {
   AuthStorage,
   createAgentSession,
+  getAgentDir,
   ModelRegistry,
   SessionManager,
+  SettingsManager,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 
+import { createReviewerResourceLoader } from "./review-session.mts";
 import { createReviewCheckTool } from "./review-tools.mts";
 
 type PlannedIssue = { id: string; title: string; branch: string };
@@ -463,6 +466,7 @@ async function reviewCompletedIssue(
     cwd: issue.worktreePath,
     tools: ["read", "grep", "find", "ls", "review_check"],
     customTools: [createReviewCheckTool(issue.worktreePath)],
+    disableExtensions: true,
     prompt,
     logFile: join(logsDir, `picastle-${issue.id}-review-${iteration}-${pass}.log`),
   });
@@ -772,6 +776,7 @@ async function runPiAgent(args: {
   cwd: string;
   tools: string[];
   customTools?: ToolDefinition[];
+  disableExtensions?: boolean;
   prompt: string;
   logFile: string;
 }): Promise<string> {
@@ -779,12 +784,22 @@ async function runPiAgent(args: {
   mkdirSync(dirname(args.logFile), { recursive: true });
   writeFileSync(args.logFile, `# ${args.name}\n# cwd: ${args.cwd}\n\n`);
 
+  const agentDir = getAgentDir();
+  const settingsManager = SettingsManager.create(args.cwd, agentDir);
+  const resourceLoader = args.disableExtensions
+    ? createReviewerResourceLoader({ cwd: args.cwd, agentDir, settingsManager })
+    : undefined;
+  if (resourceLoader) await resourceLoader.reload();
+
   const { session } = await createAgentSession({
     cwd: args.cwd,
+    agentDir,
     tools: args.tools,
     customTools: args.customTools,
     authStorage,
     modelRegistry,
+    settingsManager,
+    resourceLoader,
     sessionManager: SessionManager.inMemory(args.cwd),
     ...(THINKING ? { thinkingLevel: THINKING } : {}),
   });

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -15,7 +15,10 @@ import {
   createAgentSession,
   ModelRegistry,
   SessionManager,
+  type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+
+import { createReviewCheckTool } from "./review-tools.mts";
 
 type PlannedIssue = { id: string; title: string; branch: string };
 type CompletedIssue = PlannedIssue & { worktreePath: string };
@@ -458,7 +461,8 @@ async function reviewCompletedIssue(
   const stdout = await runPiAgent({
     name: `reviewer-${issue.id}-${pass}`,
     cwd: issue.worktreePath,
-    tools: ["read", "bash"],
+    tools: ["read", "grep", "find", "ls", "review_check"],
+    customTools: [createReviewCheckTool(issue.worktreePath)],
     prompt,
     logFile: join(logsDir, `picastle-${issue.id}-review-${iteration}-${pass}.log`),
   });
@@ -767,6 +771,7 @@ async function runPiAgent(args: {
   name: string;
   cwd: string;
   tools: string[];
+  customTools?: ToolDefinition[];
   prompt: string;
   logFile: string;
 }): Promise<string> {
@@ -777,6 +782,7 @@ async function runPiAgent(args: {
   const { session } = await createAgentSession({
     cwd: args.cwd,
     tools: args.tools,
+    customTools: args.customTools,
     authStorage,
     modelRegistry,
     sessionManager: SessionManager.inMemory(args.cwd),

--- a/pi/picastle/package.json
+++ b/pi/picastle/package.json
@@ -6,7 +6,7 @@
     "picastle": "bin/picastle"
   },
   "scripts": {
-    "typecheck": "tsc main.mts review-tools.mts --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --allowImportingTsExtensions",
+    "typecheck": "tsc main.mts review-session.mts review-tools.mts --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --allowImportingTsExtensions",
     "test": "tsx --test review-tools.test.mts",
     "prep": "bash scripts/prep.sh",
     "start": "tsx main.mts"

--- a/pi/picastle/package.json
+++ b/pi/picastle/package.json
@@ -6,7 +6,8 @@
     "picastle": "bin/picastle"
   },
   "scripts": {
-    "typecheck": "tsc main.mts --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck",
+    "typecheck": "tsc main.mts review-tools.mts --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --allowImportingTsExtensions",
+    "test": "tsx --test review-tools.test.mts",
     "prep": "bash scripts/prep.sh",
     "start": "tsx main.mts"
   },

--- a/pi/picastle/prompts/review-prompt.md
+++ b/pi/picastle/prompts/review-prompt.md
@@ -4,7 +4,7 @@ Review completed Picastle branch `{{BRANCH}}` for pebbles issue {{TASK_ID}}: {{I
 
 This is review pass {{REVIEW_PASS}} of at most {{MAX_REVIEW_CYCLES}}.
 
-You are the reviewer. Your tool permissions are read-only: you can read files and run `review_check`, a restricted allowlisted review runner. Project/local Pi extensions from the reviewed worktree are disabled for this session. Do **not** edit files. Do **not** commit. Do **not** push. Do **not** open a PR. Do **not** mutate Pebbles. Your job is to inspect, run allowed checks when appropriate, and provide structured feedback.
+You are the reviewer. Your only inspection tool is `review_check`, a restricted allowlisted review runner. Project/local Pi extensions from the reviewed worktree are disabled for this session. Do **not** edit files. Do **not** commit. Do **not** push. Do **not** open a PR. Do **not** mutate Pebbles. Your job is to inspect, run allowed checks when appropriate, and provide structured feedback.
 
 # PATHS
 
@@ -25,8 +25,8 @@ Pebbles read-only command prefix (use only with `review_check` for `show`, `list
 
 # REVIEW PROCEDURE
 
-1. Read `AGENTS.md` in the worktree.
-2. Inspect the branch with `review_check` (you do not have bash):
+1. Read `AGENTS.md` in the worktree through `review_check` (for example, `cat AGENTS.md`).
+2. Inspect the branch with `review_check` (you do not have bash or built-in filesystem tools):
 
 ```bash
 git log --oneline {{BASE_BRANCH}}..HEAD

--- a/pi/picastle/prompts/review-prompt.md
+++ b/pi/picastle/prompts/review-prompt.md
@@ -44,7 +44,7 @@ git diff {{BASE_BRANCH}}...HEAD
 
 4. If `{{VERIFY}}` is true, run relevant checks from `AGENTS.md` only through `review_check`. Prefer targeted checks first, but use full checks when the touched surface is broad or ambiguous.
 
-`review_check` rejects mutating git/gh/peb commands and general shell syntax. Standard build/test commands run in a disposable copy rather than the issue worktree. If a needed command is rejected or unavailable, record that in `checks` and explain the validation gap in `summary` or a finding.
+`review_check` rejects mutating git/gh/peb commands, general shell syntax, and copy-mode arguments that use absolute paths or parent-directory traversal. Standard build/test commands run in a disposable copy rather than the issue worktree. If a needed command is rejected or unavailable, record that in `checks` and explain the validation gap in `summary` or a finding.
 
 # OUTPUT
 

--- a/pi/picastle/prompts/review-prompt.md
+++ b/pi/picastle/prompts/review-prompt.md
@@ -42,9 +42,9 @@ git diff {{BASE_BRANCH}}...HEAD
    - code quality / architecture issues
    - docs or UX copy mismatches, if relevant
 
-4. If `{{VERIFY}}` is true, run relevant checks from `AGENTS.md` only through `review_check`. Prefer targeted checks first, but use full checks when the touched surface is broad or ambiguous.
+4. If `{{VERIFY}}` is true, run relevant read-only source inspection checks from `AGENTS.md` only through `review_check`. Do not run package scripts, test runners, compilers, or build tools; reviewers do not have a sandbox for executing branch-controlled project code. If validation requires executable checks, record that gap in `checks` and explain it in `summary` or a finding.
 
-`review_check` rejects mutating git/gh/peb commands, general shell syntax, and copy-mode arguments that use absolute paths or parent-directory traversal. Standard build/test commands run in a disposable copy rather than the issue worktree. If a needed command is rejected or unavailable, record that in `checks` and explain the validation gap in `summary` or a finding.
+`review_check` rejects mutating git/gh/peb commands, project-code execution, general shell syntax, redirects, commits, pushes, PR creation, and Pebbles writes.
 
 # OUTPUT
 
@@ -53,13 +53,13 @@ Output exactly one JSON object wrapped in `<review>` tags.
 Approved:
 
 <review>
-{"status":"approved","summary":"Looks ready.","findings":[],"checks":["cd ui && npm run test"]}
+{"status":"approved","summary":"Looks ready.","findings":[],"checks":["git diff --stat {{BASE_BRANCH}}...HEAD"]}
 </review>
 
 Changes requested:
 
 <review>
-{"status":"changes_requested","summary":"Needs a regression test.","findings":[{"severity":"blocking","file":"ui/src/example.test.tsx","summary":"Missing coverage for stale updater refresh.","recommendation":"Add a test that advances timers past the stale threshold and asserts check_for_update is invoked."}],"checks":["cd ui && npm run test"]}
+{"status":"changes_requested","summary":"Needs a regression test. Could not execute npm tests because reviewer tools do not run branch-controlled code.","findings":[{"severity":"blocking","file":"ui/src/example.test.tsx","summary":"Missing coverage for stale updater refresh.","recommendation":"Add a test that advances timers past the stale threshold and asserts check_for_update is invoked."}],"checks":["git diff {{BASE_BRANCH}}...HEAD","not run: cd ui && npm run test (project-code execution rejected)"]}
 </review>
 
 Blocked:

--- a/pi/picastle/prompts/review-prompt.md
+++ b/pi/picastle/prompts/review-prompt.md
@@ -4,7 +4,7 @@ Review completed Picastle branch `{{BRANCH}}` for pebbles issue {{TASK_ID}}: {{I
 
 This is review pass {{REVIEW_PASS}} of at most {{MAX_REVIEW_CYCLES}}.
 
-You are the reviewer. Do **not** edit files. Do **not** commit. Do **not** push. Do **not** open a PR. Your job is to inspect, run checks when appropriate, and provide structured feedback.
+You are the reviewer. Your tool permissions are read-only: you can read files and run `review_check`, a restricted allowlisted review runner. Do **not** edit files. Do **not** commit. Do **not** push. Do **not** open a PR. Do **not** mutate Pebbles. Your job is to inspect, run allowed checks when appropriate, and provide structured feedback.
 
 # PATHS
 
@@ -17,7 +17,7 @@ You are the reviewer. Do **not** edit files. Do **not** commit. Do **not** push.
 {{ISSUE_JSON}}
 </issue-json>
 
-Pebbles command prefix:
+Pebbles read-only command prefix (use only with `review_check` for `show`, `list`, or other read-only Pebbles subcommands):
 
 ```bash
 {{PEB_PREFIX}}
@@ -26,12 +26,12 @@ Pebbles command prefix:
 # REVIEW PROCEDURE
 
 1. Read `AGENTS.md` in the worktree.
-2. Inspect the branch:
+2. Inspect the branch with `review_check` (you do not have bash):
 
 ```bash
-git -C "{{WORKTREE_PATH}}" log --oneline {{BASE_BRANCH}}..HEAD
-git -C "{{WORKTREE_PATH}}" diff --stat {{BASE_BRANCH}}...HEAD
-git -C "{{WORKTREE_PATH}}" diff {{BASE_BRANCH}}...HEAD
+git log --oneline {{BASE_BRANCH}}..HEAD
+git diff --stat {{BASE_BRANCH}}...HEAD
+git diff {{BASE_BRANCH}}...HEAD
 ```
 
 3. Compare the implementation to the pebbles brief. Check for:
@@ -42,9 +42,9 @@ git -C "{{WORKTREE_PATH}}" diff {{BASE_BRANCH}}...HEAD
    - code quality / architecture issues
    - docs or UX copy mismatches, if relevant
 
-4. If `{{VERIFY}}` is true, run the relevant checks from `AGENTS.md`. Prefer targeted checks first, but use full checks when the touched surface is broad or ambiguous.
+4. If `{{VERIFY}}` is true, run relevant checks from `AGENTS.md` only through `review_check`. Prefer targeted checks first, but use full checks when the touched surface is broad or ambiguous.
 
-Checks may create normal build/test artifacts, but you must not edit source files or make commits.
+`review_check` rejects mutating git/gh/peb commands and general shell syntax. Standard build/test commands run in a disposable copy rather than the issue worktree. If a needed command is rejected or unavailable, record that in `checks` and explain the validation gap in `summary` or a finding.
 
 # OUTPUT
 

--- a/pi/picastle/prompts/review-prompt.md
+++ b/pi/picastle/prompts/review-prompt.md
@@ -4,7 +4,7 @@ Review completed Picastle branch `{{BRANCH}}` for pebbles issue {{TASK_ID}}: {{I
 
 This is review pass {{REVIEW_PASS}} of at most {{MAX_REVIEW_CYCLES}}.
 
-You are the reviewer. Your tool permissions are read-only: you can read files and run `review_check`, a restricted allowlisted review runner. Do **not** edit files. Do **not** commit. Do **not** push. Do **not** open a PR. Do **not** mutate Pebbles. Your job is to inspect, run allowed checks when appropriate, and provide structured feedback.
+You are the reviewer. Your tool permissions are read-only: you can read files and run `review_check`, a restricted allowlisted review runner. Project/local Pi extensions from the reviewed worktree are disabled for this session. Do **not** edit files. Do **not** commit. Do **not** push. Do **not** open a PR. Do **not** mutate Pebbles. Your job is to inspect, run allowed checks when appropriate, and provide structured feedback.
 
 # PATHS
 

--- a/pi/picastle/review-session.mts
+++ b/pi/picastle/review-session.mts
@@ -1,0 +1,15 @@
+import { DefaultResourceLoader, getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
+
+export function createReviewerResourceLoader(options: {
+  cwd: string;
+  agentDir?: string;
+  settingsManager?: SettingsManager;
+}): DefaultResourceLoader {
+  const agentDir = options.agentDir ?? getAgentDir();
+  return new DefaultResourceLoader({
+    cwd: options.cwd,
+    agentDir,
+    settingsManager: options.settingsManager ?? SettingsManager.create(options.cwd, agentDir),
+    noExtensions: true,
+  });
+}

--- a/pi/picastle/review-session.mts
+++ b/pi/picastle/review-session.mts
@@ -1,4 +1,18 @@
-import { DefaultResourceLoader, getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { DefaultResourceLoader, getAgentDir, SettingsManager, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+import { createReviewCheckTool } from "./review-tools.mts";
+
+export function createReviewerAgentTooling(cwd: string): {
+  tools: string[];
+  customTools: ToolDefinition[];
+  disableExtensions: true;
+} {
+  return {
+    tools: ["review_check"],
+    customTools: [createReviewCheckTool(cwd)],
+    disableExtensions: true,
+  };
+}
 
 export function createReviewerResourceLoader(options: {
   cwd: string;

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -1,11 +1,9 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 
-type ReviewCommandMode = "source" | "copy";
+type ReviewCommandMode = "source";
 type ReviewStep = { argv: string[]; cwd: string; mode: ReviewCommandMode };
 
 export type ReviewCommandPlan = {
@@ -20,7 +18,7 @@ const REVIEW_CHECK_PARAMETERS = {
     command: {
       type: "string",
       description:
-        "Single read-only review command to run. Mutating git/gh/peb commands and shell redirection are rejected.",
+        "Single read-only review command to run. Mutating git/gh/peb commands, shell redirection, and project-code execution are rejected.",
     },
   },
   required: ["command"],
@@ -28,7 +26,6 @@ const REVIEW_CHECK_PARAMETERS = {
 };
 
 const SOURCE_COMMANDS = new Set(["git", "peb", "gh", "grep", "find", "ls", "pwd", "cat", "head", "tail", "wc"]);
-const COPY_COMMANDS = new Set(["npm", "pnpm", "yarn", "bun", "deno", "cargo", "go", "pytest", "python", "python3"]);
 const READ_ONLY_GIT_SUBCOMMANDS = new Set([
   "status",
   "diff",
@@ -50,29 +47,17 @@ const ALLOWED_PEB_NESTED_SUBCOMMANDS = new Map([
   ["closure", new Set(["show"])],
 ]);
 const READ_ONLY_GH_SUBCOMMANDS = new Map([["pr", new Set(["list", "view", "diff", "checks"])]]);
-const PACKAGE_SCRIPTS = new Set([
-  "test",
-  "tests",
-  "lint",
-  "build",
-  "check",
-  "typecheck",
-  "type-check",
-  "fmt:check",
-  "format:check",
-]);
-
 export function createReviewCheckTool(root: string): ToolDefinition {
   const reviewRoot = resolve(root);
   return defineTool({
     name: "review_check",
     label: "review_check",
     description:
-      "Run a restricted read-only review command. Git/Pebbles/GitHub inspection commands run in the worktree; build/test checks run in a disposable copy. Mutating commands, shell operators, redirects, commits, pushes, PR creation, Pebbles writes, and copy-mode paths escaping the disposable copy are rejected.",
+      "Run a restricted read-only review command for source inspection. Project-code execution (package scripts, test runners, compilers, and build tools), mutating commands, shell operators, redirects, commits, pushes, PR creation, and Pebbles writes are rejected.",
     promptSnippet: "Run allowlisted read-only review checks without granting a general shell",
     promptGuidelines: [
-      "Use review_check instead of bash for git diff/log/status and project verification commands.",
-      "Do not attempt mutating commands or output paths in the real worktree; review_check rejects edits, commits, pushes, PR creation, Pebbles writes, and copy-mode path escapes.",
+      "Use review_check instead of bash for git diff/log/status and other read-only source inspection commands.",
+      "Do not attempt package scripts, test runners, compilers, mutating commands, or output paths; review_check rejects project-code execution, edits, commits, pushes, PR creation, and Pebbles writes.",
     ],
     parameters: REVIEW_CHECK_PARAMETERS as any,
     async execute(_toolCallId, params: { command: string }) {
@@ -117,16 +102,12 @@ export function planReviewCommand(command: string, root: string): ReviewCommandP
   }
 
   if (steps.length === 0) throw new Error("review_check command must include a command to run");
-  const mode = steps.some((step) => step.mode === "copy") ? "copy" : "source";
-  if (mode === "copy" && steps.some((step) => step.mode === "source" && step.argv[0] === "git")) {
-    throw new Error("review_check does not allow mixing git inspection with disposable-copy checks");
-  }
-  return { command, mode, steps };
+  return { command, mode: "source", steps };
 }
 
 function normalizeCommand(argv: string[], cwd: string, root: string): ReviewStep {
   const command = argv[0]!;
-  if (!SOURCE_COMMANDS.has(command) && !COPY_COMMANDS.has(command)) {
+  if (!SOURCE_COMMANDS.has(command)) {
     throw new Error(`review_check does not allow command: ${command}`);
   }
 
@@ -134,12 +115,8 @@ function normalizeCommand(argv: string[], cwd: string, root: string): ReviewStep
   if (command === "peb") return normalizePebCommand(argv, cwd);
   if (command === "gh") return normalizeGhCommand(argv, cwd);
   if (command === "find") ensureFindIsReadOnly(argv);
-  if (COPY_COMMANDS.has(command)) {
-    ensureCopyCommandAllowed(argv);
-    ensureCopyCommandArgsStayInCopy(argv);
-  }
 
-  return { argv, cwd, mode: COPY_COMMANDS.has(command) ? "copy" : "source" };
+  return { argv, cwd, mode: "source" };
 }
 
 function normalizeGitCommand(argv: string[], cwd: string, root: string): ReviewStep {
@@ -206,71 +183,19 @@ function normalizeGhCommand(argv: string[], cwd: string): ReviewStep {
   return { argv, cwd, mode: "source" };
 }
 
-function ensureCopyCommandAllowed(argv: string[]): void {
-  const [command, subcommand, script] = argv;
-  if (command === "npm") {
-    if (subcommand === "test") return;
-    if (subcommand === "run" && script && isAllowedPackageScript(script)) return;
-    throw new Error(`review_check only allows npm test or npm run ${[...PACKAGE_SCRIPTS].join("|")}`);
-  }
-  if (command === "pnpm" || command === "yarn") {
-    if (subcommand && isAllowedPackageScript(subcommand)) return;
-    if (subcommand === "run" && script && isAllowedPackageScript(script)) return;
-    throw new Error(`review_check only allows ${command} review scripts such as test, lint, build, or typecheck`);
-  }
-  if (command === "bun") {
-    if (subcommand === "test") return;
-    if (subcommand === "run" && script && isAllowedPackageScript(script)) return;
-    throw new Error("review_check only allows bun test or bun run review scripts");
-  }
-  if (command === "deno") {
-    if (subcommand === "test" || subcommand === "check" || subcommand === "lint") return;
-    throw new Error("review_check only allows deno test, deno check, or deno lint");
-  }
-  if (command === "cargo") {
-    if (subcommand === "fmt" && !argv.includes("--check")) {
-      throw new Error("review_check only allows cargo fmt when --check is present");
-    }
-    if (["test", "check", "clippy", "fmt", "build"].includes(subcommand ?? "")) return;
-    throw new Error("review_check only allows cargo test/check/clippy/fmt --check/build");
-  }
-  if (command === "go") {
-    if (subcommand === "test" || subcommand === "vet") return;
-    throw new Error("review_check only allows go test or go vet");
-  }
-  if (command === "pytest") return;
-  if ((command === "python" || command === "python3") && subcommand === "-m" && script === "pytest") return;
-  throw new Error(`review_check does not allow command: ${command}`);
-}
-
-function isAllowedPackageScript(script: string): boolean {
-  return PACKAGE_SCRIPTS.has(script) || /^(test|lint|build|check|typecheck|type-check)(:|$)/.test(script);
-}
-
-function ensureCopyCommandArgsStayInCopy(argv: string[]): void {
-  const unsafe = argv.find((arg) => argReferencesPathOutsideCopy(arg));
-  if (unsafe) {
-    throw new Error(`review_check copy-mode arguments must stay within the disposable copy: ${unsafe}`);
-  }
-}
-
-function argReferencesPathOutsideCopy(arg: string): boolean {
-  return argValueParts(arg).some((part) => isAbsolute(part) || hasParentPathSegment(part));
-}
-
-function argValueParts(arg: string): string[] {
-  const equalsIndex = arg.indexOf("=");
-  if (equalsIndex === -1) return [arg];
-  return [arg, arg.slice(equalsIndex + 1)].filter(Boolean);
-}
-
-function hasParentPathSegment(value: string): boolean {
-  return value.split(/[\\/]+/).includes("..");
-}
-
 function ensureFindIsReadOnly(argv: string[]): void {
-  const forbidden = new Set(["-exec", "-execdir", "-ok", "-okdir", "-delete", "-fls", "-fprint", "-fprintf"]);
-  const found = argv.find((arg) => forbidden.has(arg));
+  const forbiddenWriteActions = new Set([
+    "-delete",
+    "-exec",
+    "-execdir",
+    "-fls",
+    "-fprint",
+    "-fprint0",
+    "-fprintf",
+    "-ok",
+    "-okdir",
+  ]);
+  const found = argv.find((arg) => forbiddenWriteActions.has(arg));
   if (found) throw new Error(`review_check does not allow find action: ${found}`);
 }
 
@@ -297,39 +222,24 @@ function ensureNoGitWriteOptions(argv: string[]): void {
   if (forbidden) throw new Error(`review_check does not allow git option: ${forbidden}`);
 }
 
-function executeReviewCommandPlan(plan: ReviewCommandPlan, root: string): { status: number; stdout: string; stderr: string } {
-  if (plan.mode === "source") return executeSteps(plan.steps, root, root);
-
-  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-review-"));
-  const scratchRoot = join(tempRoot, "repo");
-  try {
-    const guardBin = join(tempRoot, "bin");
-    createReviewGuardBin(guardBin);
-    copyWorktree(root, scratchRoot);
-    return executeSteps(plan.steps, root, scratchRoot, guardBin);
-  } finally {
-    rmSync(tempRoot, { recursive: true, force: true });
-  }
+function executeReviewCommandPlan(plan: ReviewCommandPlan, _root: string): { status: number; stdout: string; stderr: string } {
+  return executeSteps(plan.steps);
 }
 
 function executeSteps(
   steps: ReviewStep[],
-  sourceRoot: string,
-  executionRoot: string,
-  guardBin?: string,
 ): { status: number; stdout: string; stderr: string } {
   let stdout = "";
   let stderr = "";
 
   for (const step of steps) {
-    const cwd = mapCwd(step.cwd, sourceRoot, executionRoot);
     const argv = step.argv[0] === "git" ? gitArgv(step.argv) : step.argv;
     const result = spawnSync(argv[0]!, argv.slice(1), {
-      cwd,
+      cwd: step.cwd,
       encoding: "utf8",
       maxBuffer: 1024 * 1024 * 20,
       timeout: 10 * 60 * 1000,
-      env: reviewCommandEnv(guardBin),
+      env: reviewCommandEnv(),
     });
     stdout += result.stdout ?? "";
     stderr += result.stderr ?? "";
@@ -344,69 +254,15 @@ function gitArgv(argv: string[]): string[] {
   return ["git", "-c", "core.pager=cat", "-c", "diff.external=", ...argv.slice(1)];
 }
 
-function reviewCommandEnv(guardBin?: string): NodeJS.ProcessEnv {
+function reviewCommandEnv(): NodeJS.ProcessEnv {
   return {
     ...process.env,
-    PATH: guardBin ? `${guardBin}${process.env.PATH ? `:${process.env.PATH}` : ""}` : process.env.PATH,
     GIT_TERMINAL_PROMPT: "0",
     GIT_OPTIONAL_LOCKS: "0",
     GIT_PAGER: "cat",
     GIT_EXTERNAL_DIFF: "",
     GH_PROMPT_DISABLED: "1",
   };
-}
-
-function createReviewGuardBin(guardBin: string): void {
-  mkdirSync(guardBin, { recursive: true });
-  writeExecutable(
-    join(guardBin, "peb"),
-    `#!/usr/bin/env bash\necho "review_check blocks Pebbles during disposable-copy checks" >&2\nexit 126\n`,
-  );
-  writeExecutable(
-    join(guardBin, "gh"),
-    `#!/usr/bin/env bash\necho "review_check blocks gh during disposable-copy checks" >&2\nexit 126\n`,
-  );
-
-  const gitPath = resolveExecutable("git");
-  writeExecutable(
-    join(guardBin, "git"),
-    `#!/usr/bin/env bash\nset -euo pipefail\nargs=("$@")\nwhile [[ \${#args[@]} -gt 0 ]]; do\n  case "\${args[0]}" in\n    -c) args=("\${args[@]:2}") ;;\n    -C) args=("\${args[@]:2}") ;;\n    --no-pager) args=("\${args[@]:1}") ;;\n    -*) echo "review_check blocks git global option during disposable-copy checks: \${args[0]}" >&2; exit 126 ;;\n    *) break ;;\n  esac\ndone\ncase "\${args[0]:-}" in\n  add|am|apply|bisect|checkout|cherry-pick|clean|clone|commit|fetch|init|merge|mv|pull|push|rebase|remote|reset|restore|revert|rm|stash|submodule|switch|tag|worktree)\n    echo "review_check blocks mutating git during disposable-copy checks: \${args[0]}" >&2\n    exit 126\n    ;;\nesac\nexec ${shSingleQuote(gitPath)} "$@"\n`,
-  );
-}
-
-function writeExecutable(path: string, content: string): void {
-  writeFileSync(path, content);
-  chmodSync(path, 0o755);
-}
-
-function resolveExecutable(name: string): string {
-  const result = spawnSync("/usr/bin/env", ["which", name], { encoding: "utf8" });
-  const path = result.stdout.trim();
-  if (!path) throw new Error(`review_check could not locate required executable: ${name}`);
-  return path;
-}
-
-function shSingleQuote(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
-
-function copyWorktree(sourceRoot: string, scratchRoot: string): void {
-  const resolvedRoot = resolve(sourceRoot);
-  cpSync(resolvedRoot, scratchRoot, {
-    recursive: true,
-    dereference: false,
-    filter(source) {
-      const rel = relative(resolvedRoot, source);
-      if (!rel) return true;
-      const [first] = rel.split(sep);
-      return ![".git", ".picastle", "target", ".next", "coverage"].includes(first ?? "");
-    },
-  });
-}
-
-function mapCwd(cwd: string, sourceRoot: string, executionRoot: string): string {
-  const rel = relative(resolve(sourceRoot), resolve(cwd));
-  return rel ? join(executionRoot, rel) : executionRoot;
 }
 
 function resolveReviewPath(root: string, cwd: string, path: string): string {

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -1,0 +1,455 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+type ReviewCommandMode = "source" | "copy";
+type ReviewStep = { argv: string[]; cwd: string; mode: ReviewCommandMode };
+
+export type ReviewCommandPlan = {
+  command: string;
+  mode: ReviewCommandMode;
+  steps: ReviewStep[];
+};
+
+const REVIEW_CHECK_PARAMETERS = {
+  type: "object",
+  properties: {
+    command: {
+      type: "string",
+      description:
+        "Single read-only review command to run. Mutating git/gh/peb commands and shell redirection are rejected.",
+    },
+  },
+  required: ["command"],
+  additionalProperties: false,
+};
+
+const SOURCE_COMMANDS = new Set(["git", "peb", "gh", "rg", "grep", "find", "ls", "pwd", "cat", "head", "tail", "wc"]);
+const COPY_COMMANDS = new Set(["npm", "pnpm", "yarn", "bun", "deno", "cargo", "go", "pytest", "python", "python3"]);
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
+  "status",
+  "diff",
+  "log",
+  "show",
+  "rev-parse",
+  "rev-list",
+  "ls-files",
+  "grep",
+  "blame",
+  "branch",
+  "describe",
+  "merge-base",
+]);
+const READ_ONLY_PEB_SUBCOMMANDS = new Set(["show", "list", "pr"]);
+const ALLOWED_PEB_NESTED_SUBCOMMANDS = new Map([
+  ["dep", new Set(["list"])],
+  ["comment", new Set(["list"])],
+  ["closure", new Set(["show"])],
+]);
+const READ_ONLY_GH_SUBCOMMANDS = new Map([["pr", new Set(["list", "view", "diff", "checks"])]]);
+const PACKAGE_SCRIPTS = new Set([
+  "test",
+  "tests",
+  "lint",
+  "build",
+  "check",
+  "typecheck",
+  "type-check",
+  "fmt:check",
+  "format:check",
+]);
+
+export function createReviewCheckTool(root: string): ToolDefinition {
+  const reviewRoot = resolve(root);
+  return defineTool({
+    name: "review_check",
+    label: "review_check",
+    description:
+      "Run a restricted read-only review command. Git/Pebbles/GitHub inspection commands run in the worktree; build/test checks run in a disposable copy. Mutating commands, shell operators, redirects, commits, pushes, PR creation, and Pebbles writes are rejected.",
+    promptSnippet: "Run allowlisted read-only review checks without granting a general shell",
+    promptGuidelines: [
+      "Use review_check instead of bash for git diff/log/status and project verification commands.",
+      "Do not attempt mutating commands; review_check rejects edits, commits, pushes, PR creation, and Pebbles writes.",
+    ],
+    parameters: REVIEW_CHECK_PARAMETERS as any,
+    async execute(_toolCallId, params: { command: string }) {
+      const command = String(params.command ?? "").trim();
+      const plan = planReviewCommand(command, reviewRoot);
+      const result = executeReviewCommandPlan(plan, reviewRoot);
+      const output = [`$ ${command}`, `mode: ${plan.mode}`, result.stdout, result.stderr]
+        .filter(Boolean)
+        .join("\n");
+      if (result.status !== 0) {
+        throw new Error(`${truncateOutput(output)}\n\nCommand exited with code ${result.status}`);
+      }
+      return {
+        content: [{ type: "text", text: truncateOutput(output || "(no output)") }],
+        details: { command, mode: plan.mode, status: result.status },
+      };
+    },
+  });
+}
+
+export function planReviewCommand(command: string, root: string): ReviewCommandPlan {
+  const reviewRoot = resolve(root);
+  if (!command.trim()) throw new Error("review_check requires a command");
+
+  const segments = splitCommandChain(command);
+  const steps: ReviewStep[] = [];
+  let cwd = reviewRoot;
+
+  for (const segment of segments) {
+    const argv = splitShellWords(segment);
+    if (argv.length === 0) continue;
+
+    if (argv[0] === "cd") {
+      if (argv.length !== 2) throw new Error("review_check only supports `cd <path>` as a chain step");
+      cwd = resolveReviewPath(reviewRoot, cwd, argv[1]!);
+      continue;
+    }
+
+    const normalized = normalizeCommand(argv, cwd, reviewRoot);
+    steps.push(normalized);
+    cwd = normalized.cwd;
+  }
+
+  if (steps.length === 0) throw new Error("review_check command must include a command to run");
+  const mode = steps.some((step) => step.mode === "copy") ? "copy" : "source";
+  if (mode === "copy" && steps.some((step) => step.mode === "source" && step.argv[0] === "git")) {
+    throw new Error("review_check does not allow mixing git inspection with disposable-copy checks");
+  }
+  return { command, mode, steps };
+}
+
+function normalizeCommand(argv: string[], cwd: string, root: string): ReviewStep {
+  const command = argv[0]!;
+  if (!SOURCE_COMMANDS.has(command) && !COPY_COMMANDS.has(command)) {
+    throw new Error(`review_check does not allow command: ${command}`);
+  }
+
+  if (command === "git") return normalizeGitCommand(argv, cwd, root);
+  if (command === "peb") return normalizePebCommand(argv, cwd);
+  if (command === "gh") return normalizeGhCommand(argv, cwd);
+  if (command === "find") ensureFindIsReadOnly(argv);
+  if (COPY_COMMANDS.has(command)) ensureCopyCommandAllowed(argv);
+
+  return { argv, cwd, mode: COPY_COMMANDS.has(command) ? "copy" : "source" };
+}
+
+function normalizeGitCommand(argv: string[], cwd: string, root: string): ReviewStep {
+  const normalized = [...argv];
+  let gitCwd = cwd;
+  for (let i = 1; i < normalized.length;) {
+    const arg = normalized[i];
+    if (arg === "-C") {
+      const path = normalized[i + 1];
+      if (!path) throw new Error("git -C requires a path");
+      gitCwd = resolveReviewPath(root, gitCwd, path);
+      normalized.splice(i, 2);
+      continue;
+    }
+    if (arg === "--no-pager") {
+      normalized.splice(i, 1);
+      continue;
+    }
+    if (arg?.startsWith("-")) throw new Error(`review_check does not allow git global option: ${arg}`);
+    break;
+  }
+
+  const subcommand = normalized[1];
+  if (!subcommand || !READ_ONLY_GIT_SUBCOMMANDS.has(subcommand)) {
+    throw new Error(`review_check does not allow git subcommand: ${subcommand ?? "<missing>"}`);
+  }
+  ensureNoGitWriteOptions(normalized);
+  ensureGitSubcommandArgsReadOnly(normalized);
+  return { argv: normalized, cwd: gitCwd, mode: "source" };
+}
+
+function normalizePebCommand(argv: string[], cwd: string): ReviewStep {
+  let index = 1;
+  while (index < argv.length) {
+    const arg = argv[index]!;
+    if (arg === "--remote" || arg === "-R" || arg === "--repo") {
+      if (!argv[index + 1]) throw new Error(`${arg} requires a value`);
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--remote=") || arg.startsWith("--repo=")) {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) throw new Error(`review_check does not allow peb option: ${arg}`);
+    break;
+  }
+
+  const subcommand = argv[index];
+  if (!subcommand) throw new Error("review_check requires a peb subcommand");
+  if (READ_ONLY_PEB_SUBCOMMANDS.has(subcommand)) return { argv, cwd, mode: "source" };
+
+  const nested = ALLOWED_PEB_NESTED_SUBCOMMANDS.get(subcommand);
+  if (nested?.has(argv[index + 1]!)) return { argv, cwd, mode: "source" };
+  throw new Error(`review_check does not allow peb subcommand: ${subcommand} ${argv[index + 1] ?? ""}`.trim());
+}
+
+function normalizeGhCommand(argv: string[], cwd: string): ReviewStep {
+  const area = argv[1];
+  const subcommand = argv[2];
+  if (!area || !subcommand || !READ_ONLY_GH_SUBCOMMANDS.get(area)?.has(subcommand)) {
+    throw new Error(`review_check does not allow gh command: ${argv.slice(1).join(" ") || "<missing>"}`);
+  }
+  return { argv, cwd, mode: "source" };
+}
+
+function ensureCopyCommandAllowed(argv: string[]): void {
+  const [command, subcommand, script] = argv;
+  if (command === "npm") {
+    if (subcommand === "test") return;
+    if (subcommand === "run" && script && isAllowedPackageScript(script)) return;
+    throw new Error(`review_check only allows npm test or npm run ${[...PACKAGE_SCRIPTS].join("|")}`);
+  }
+  if (command === "pnpm" || command === "yarn") {
+    if (subcommand && isAllowedPackageScript(subcommand)) return;
+    if (subcommand === "run" && script && isAllowedPackageScript(script)) return;
+    throw new Error(`review_check only allows ${command} review scripts such as test, lint, build, or typecheck`);
+  }
+  if (command === "bun") {
+    if (subcommand === "test") return;
+    if (subcommand === "run" && script && isAllowedPackageScript(script)) return;
+    throw new Error("review_check only allows bun test or bun run review scripts");
+  }
+  if (command === "deno") {
+    if (subcommand === "test" || subcommand === "check" || subcommand === "lint") return;
+    throw new Error("review_check only allows deno test, deno check, or deno lint");
+  }
+  if (command === "cargo") {
+    if (subcommand === "fmt" && !argv.includes("--check")) {
+      throw new Error("review_check only allows cargo fmt when --check is present");
+    }
+    if (["test", "check", "clippy", "fmt", "build"].includes(subcommand ?? "")) return;
+    throw new Error("review_check only allows cargo test/check/clippy/fmt --check/build");
+  }
+  if (command === "go") {
+    if (subcommand === "test" || subcommand === "vet") return;
+    throw new Error("review_check only allows go test or go vet");
+  }
+  if (command === "pytest") return;
+  if ((command === "python" || command === "python3") && subcommand === "-m" && script === "pytest") return;
+  throw new Error(`review_check does not allow command: ${command}`);
+}
+
+function isAllowedPackageScript(script: string): boolean {
+  return PACKAGE_SCRIPTS.has(script) || /^(test|lint|build|check|typecheck|type-check)(:|$)/.test(script);
+}
+
+function ensureFindIsReadOnly(argv: string[]): void {
+  const forbidden = new Set(["-exec", "-execdir", "-ok", "-okdir", "-delete", "-fls", "-fprint", "-fprintf"]);
+  const found = argv.find((arg) => forbidden.has(arg));
+  if (found) throw new Error(`review_check does not allow find action: ${found}`);
+}
+
+function ensureGitSubcommandArgsReadOnly(argv: string[]): void {
+  const subcommand = argv[1];
+  if (subcommand !== "branch") return;
+
+  const safeBranchFlags = new Set(["--show-current", "--list", "-a", "--all", "-r", "--remotes", "-v", "-vv"]);
+  const unsafe = argv.slice(2).find((arg) => !safeBranchFlags.has(arg));
+  if (unsafe) throw new Error(`review_check does not allow git branch argument: ${unsafe}`);
+}
+
+function ensureNoGitWriteOptions(argv: string[]): void {
+  const forbidden = argv.find(
+    (arg) =>
+      arg === "--output" ||
+      arg.startsWith("--output=") ||
+      arg === "--ext-diff" ||
+      arg === "--no-index" ||
+      arg === "--exec" ||
+      arg.startsWith("--exec=") ||
+      arg === "-o",
+  );
+  if (forbidden) throw new Error(`review_check does not allow git option: ${forbidden}`);
+}
+
+function executeReviewCommandPlan(plan: ReviewCommandPlan, root: string): { status: number; stdout: string; stderr: string } {
+  if (plan.mode === "source") return executeSteps(plan.steps, root, root);
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-review-"));
+  const scratchRoot = join(tempRoot, "repo");
+  try {
+    const guardBin = join(tempRoot, "bin");
+    createReviewGuardBin(guardBin);
+    copyWorktree(root, scratchRoot);
+    return executeSteps(plan.steps, root, scratchRoot, guardBin);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function executeSteps(
+  steps: ReviewStep[],
+  sourceRoot: string,
+  executionRoot: string,
+  guardBin?: string,
+): { status: number; stdout: string; stderr: string } {
+  let stdout = "";
+  let stderr = "";
+
+  for (const step of steps) {
+    const cwd = mapCwd(step.cwd, sourceRoot, executionRoot);
+    const argv = step.argv[0] === "git" ? gitArgv(step.argv) : step.argv;
+    const result = spawnSync(argv[0]!, argv.slice(1), {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 20,
+      timeout: 10 * 60 * 1000,
+      env: reviewCommandEnv(guardBin),
+    });
+    stdout += result.stdout ?? "";
+    stderr += result.stderr ?? "";
+    const status = result.status ?? (result.error ? 1 : 0);
+    if (status !== 0) return { status, stdout, stderr: stderr + (result.error ? String(result.error) : "") };
+  }
+
+  return { status: 0, stdout, stderr };
+}
+
+function gitArgv(argv: string[]): string[] {
+  return ["git", "-c", "core.pager=cat", "-c", "diff.external=", ...argv.slice(1)];
+}
+
+function reviewCommandEnv(guardBin?: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PATH: guardBin ? `${guardBin}${process.env.PATH ? `:${process.env.PATH}` : ""}` : process.env.PATH,
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_PAGER: "cat",
+    GIT_EXTERNAL_DIFF: "",
+    GH_PROMPT_DISABLED: "1",
+  };
+}
+
+function createReviewGuardBin(guardBin: string): void {
+  mkdirSync(guardBin, { recursive: true });
+  writeExecutable(
+    join(guardBin, "peb"),
+    `#!/usr/bin/env bash\necho "review_check blocks Pebbles during disposable-copy checks" >&2\nexit 126\n`,
+  );
+  writeExecutable(
+    join(guardBin, "gh"),
+    `#!/usr/bin/env bash\necho "review_check blocks gh during disposable-copy checks" >&2\nexit 126\n`,
+  );
+
+  const gitPath = resolveExecutable("git");
+  writeExecutable(
+    join(guardBin, "git"),
+    `#!/usr/bin/env bash\nset -euo pipefail\nargs=("$@")\nwhile [[ \${#args[@]} -gt 0 ]]; do\n  case "\${args[0]}" in\n    -c) args=("\${args[@]:2}") ;;\n    -C) args=("\${args[@]:2}") ;;\n    --no-pager) args=("\${args[@]:1}") ;;\n    -*) echo "review_check blocks git global option during disposable-copy checks: \${args[0]}" >&2; exit 126 ;;\n    *) break ;;\n  esac\ndone\ncase "\${args[0]:-}" in\n  add|am|apply|bisect|checkout|cherry-pick|clean|clone|commit|fetch|init|merge|mv|pull|push|rebase|remote|reset|restore|revert|rm|stash|submodule|switch|tag|worktree)\n    echo "review_check blocks mutating git during disposable-copy checks: \${args[0]}" >&2\n    exit 126\n    ;;\nesac\nexec ${shSingleQuote(gitPath)} "$@"\n`,
+  );
+}
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+function resolveExecutable(name: string): string {
+  const result = spawnSync("/usr/bin/env", ["which", name], { encoding: "utf8" });
+  const path = result.stdout.trim();
+  if (!path) throw new Error(`review_check could not locate required executable: ${name}`);
+  return path;
+}
+
+function shSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function copyWorktree(sourceRoot: string, scratchRoot: string): void {
+  const resolvedRoot = resolve(sourceRoot);
+  cpSync(resolvedRoot, scratchRoot, {
+    recursive: true,
+    dereference: false,
+    filter(source) {
+      const rel = relative(resolvedRoot, source);
+      if (!rel) return true;
+      const [first] = rel.split(sep);
+      return ![".git", ".picastle", "target", ".next", "coverage"].includes(first ?? "");
+    },
+  });
+}
+
+function mapCwd(cwd: string, sourceRoot: string, executionRoot: string): string {
+  const rel = relative(resolve(sourceRoot), resolve(cwd));
+  return rel ? join(executionRoot, rel) : executionRoot;
+}
+
+function resolveReviewPath(root: string, cwd: string, path: string): string {
+  if (path === "~" || path.startsWith("~/")) throw new Error("review_check paths must stay inside the worktree");
+  const resolved = resolve(isAbsolute(path) ? path : join(cwd, path));
+  if (!isInside(root, resolved)) throw new Error(`review_check path escapes the worktree: ${path}`);
+  return resolved;
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = relative(resolve(root), resolve(candidate));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function splitCommandChain(command: string): string[] {
+  const segments: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i]!;
+    if (char === "\n" || char === "\r" || char === ";" || char === "|" || char === "<" || char === ">" || char === "`") {
+      throw new Error(`review_check does not allow shell operator: ${JSON.stringify(char)}`);
+    }
+    if (!quote && char === "&") {
+      if (command[i + 1] === "&") {
+        segments.push(current.trim());
+        current = "";
+        i++;
+        continue;
+      }
+      throw new Error("review_check only allows && as a command separator");
+    }
+    if (char === "'" || char === '"') quote = quote === char ? undefined : quote ?? char;
+    current += char;
+  }
+  if (quote) throw new Error("review_check command has an unterminated quote");
+  if (current.trim()) segments.push(current.trim());
+  return segments.filter(Boolean);
+}
+
+function splitShellWords(segment: string): string[] {
+  const words: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+
+  for (let i = 0; i < segment.length; i++) {
+    const char = segment[i]!;
+    if (char === "\\") throw new Error("review_check does not allow shell escapes");
+    if (char === "'" || char === '"') {
+      quote = quote === char ? undefined : quote ?? char;
+      continue;
+    }
+    if (!quote && /\s/.test(char)) {
+      if (current) {
+        words.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (quote) throw new Error("review_check command has an unterminated quote");
+  if (current) words.push(current);
+  return words;
+}
+
+function truncateOutput(output: string): string {
+  const max = 50_000;
+  return output.length <= max ? output : `${output.slice(0, max)}\n... truncated ...`;
+}

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -27,7 +27,7 @@ const REVIEW_CHECK_PARAMETERS = {
   additionalProperties: false,
 };
 
-const SOURCE_COMMANDS = new Set(["git", "peb", "gh", "rg", "grep", "find", "ls", "pwd", "cat", "head", "tail", "wc"]);
+const SOURCE_COMMANDS = new Set(["git", "peb", "gh", "grep", "find", "ls", "pwd", "cat", "head", "tail", "wc"]);
 const COPY_COMMANDS = new Set(["npm", "pnpm", "yarn", "bun", "deno", "cargo", "go", "pytest", "python", "python3"]);
 const READ_ONLY_GIT_SUBCOMMANDS = new Set([
   "status",
@@ -349,6 +349,7 @@ function reviewCommandEnv(guardBin?: string): NodeJS.ProcessEnv {
     ...process.env,
     PATH: guardBin ? `${guardBin}${process.env.PATH ? `:${process.env.PATH}` : ""}` : process.env.PATH,
     GIT_TERMINAL_PROMPT: "0",
+    GIT_OPTIONAL_LOCKS: "0",
     GIT_PAGER: "cat",
     GIT_EXTERNAL_DIFF: "",
     GH_PROMPT_DISABLED: "1",

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -213,7 +213,8 @@ function ensureNoGitWriteOptions(argv: string[]): void {
     (arg) =>
       arg === "--output" ||
       arg.startsWith("--output=") ||
-      arg === "--ext-diff" ||
+      isGitOptionAbbreviation(arg, "--ext-diff") ||
+      isGitOptionAbbreviation(arg, "--textconv") ||
       arg === "--no-index" ||
       arg === "--exec" ||
       arg.startsWith("--exec=") ||
@@ -222,6 +223,12 @@ function ensureNoGitWriteOptions(argv: string[]): void {
       arg === "-o",
   );
   if (forbidden) throw new Error(`review_check does not allow git option: ${forbidden}`);
+}
+
+function isGitOptionAbbreviation(arg: string, fullOption: string): boolean {
+  if (!arg.startsWith("--") || arg.startsWith("--no-")) return false;
+  const optionName = arg.split("=", 1)[0]!;
+  return optionName.length > 2 && fullOption.startsWith(optionName);
 }
 
 function isGitOpenFilesInPagerOption(arg: string): boolean {
@@ -263,7 +270,37 @@ function executeSteps(
 }
 
 function gitArgv(argv: string[]): string[] {
-  return ["git", "-c", "core.pager=cat", "-c", "diff.external=", ...argv.slice(1)];
+  const subcommand = argv[1];
+  const hardenedArgs = gitSubcommandArgvWithReadOnlyGuards(argv);
+  return [
+    "git",
+    "-c",
+    "core.pager=cat",
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "core.hooksPath=/dev/null",
+    "-c",
+    "diff.external=",
+    "-c",
+    "credential.helper=",
+    ...hardenedArgs.slice(subcommand ? 1 : 0),
+  ];
+}
+
+function gitSubcommandArgvWithReadOnlyGuards(argv: string[]): string[] {
+  const subcommand = argv[1];
+  if (!subcommand) return argv;
+
+  if (subcommand === "diff" || subcommand === "log" || subcommand === "show") {
+    return ["git", subcommand, "--no-ext-diff", "--no-textconv", ...argv.slice(2)];
+  }
+
+  if (subcommand === "grep" || subcommand === "blame") {
+    return ["git", subcommand, "--no-textconv", ...argv.slice(2)];
+  }
+
+  return argv;
 }
 
 function reviewCommandEnv(): NodeJS.ProcessEnv {

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -164,6 +164,8 @@ function normalizeGitCommand(argv: string[], cwd: string, root: string): ReviewS
 }
 
 function normalizePebCommand(argv: string[], cwd: string, root: string): ReviewStep {
+  ensurePebRepositoryOptionsAreSafe(argv, cwd, root);
+
   let index = 1;
   while (index < argv.length) {
     const arg = argv[index]!;
@@ -178,6 +180,10 @@ function normalizePebCommand(argv: string[], cwd: string, root: string): ReviewS
       const [option, value] = splitLongOption(arg);
       if (!value) throw new Error(`${option} requires a value`);
       ensurePebRepositoryOptionIsSafe(option, value, cwd, root);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-R") && arg !== "-R") {
       index += 1;
       continue;
     }
@@ -633,6 +639,28 @@ function realpathForExistingPrefix(path: string): string | undefined {
   }
 }
 
+function ensurePebRepositoryOptionsAreSafe(argv: string[], cwd: string, root: string): void {
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--remote" || arg === "-R" || arg === "--repo") {
+      const value = argv[i + 1];
+      if (!value) throw new Error(`${arg} requires a value`);
+      ensurePebRepositoryOptionIsSafe(arg, value, cwd, root);
+      i++;
+      continue;
+    }
+    if (arg.startsWith("--remote=") || arg.startsWith("--repo=")) {
+      const [option, value] = splitLongOption(arg);
+      if (!value) throw new Error(`${option} requires a value`);
+      ensurePebRepositoryOptionIsSafe(option, value, cwd, root);
+      continue;
+    }
+    if (arg.startsWith("-R") && arg !== "-R") {
+      ensurePebRepositoryOptionIsSafe("-R", arg.slice(2), cwd, root);
+    }
+  }
+}
+
 function ensurePebRepositoryOptionIsSafe(option: string, value: string, cwd: string, root: string): void {
   if (value.startsWith("~") || hasParentDirectorySegment(value) || isAbsolute(value)) {
     throw new Error(`review_check does not allow peb ${option} path escapes: ${value}`);
@@ -671,6 +699,7 @@ function ensureNoGitWriteOptions(argv: string[]): void {
       isGitOptionAbbreviation(arg, "--ext-diff") ||
       isGitOptionAbbreviation(arg, "--textconv") ||
       isGitOptionAbbreviation(arg, "--contents") ||
+      isGitOptionAbbreviation(arg, "--show-signature") ||
       arg === "--no-index" ||
       arg === "--exec" ||
       arg.startsWith("--exec=") ||
@@ -747,6 +776,10 @@ function gitArgv(argv: string[]): string[] {
     "core.hooksPath=/dev/null",
     "-c",
     "diff.external=",
+    "-c",
+    "log.showSignature=false",
+    "-c",
+    "gpg.program=false",
     "-c",
     "credential.helper=",
     ...hardenedArgs.slice(subcommand ? 1 : 0),

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -217,13 +217,21 @@ function ensureNoGitWriteOptions(argv: string[]): void {
       arg === "--no-index" ||
       arg === "--exec" ||
       arg.startsWith("--exec=") ||
-      arg === "--open-files-in-pager" ||
-      arg.startsWith("--open-files-in-pager=") ||
-      arg === "-O" ||
-      arg.startsWith("-O") ||
+      isGitOpenFilesInPagerOption(arg) ||
+      isGitOpenFilesInPagerShortOption(arg) ||
       arg === "-o",
   );
   if (forbidden) throw new Error(`review_check does not allow git option: ${forbidden}`);
+}
+
+function isGitOpenFilesInPagerOption(arg: string): boolean {
+  if (!arg.startsWith("--")) return false;
+  const optionName = arg.split("=", 1)[0]!;
+  return optionName.length > 2 && "--open-files-in-pager".startsWith(optionName);
+}
+
+function isGitOpenFilesInPagerShortOption(arg: string): boolean {
+  return arg.startsWith("-") && !arg.startsWith("--") && arg.slice(1).includes("O");
 }
 
 function executeReviewCommandPlan(plan: ReviewCommandPlan, _root: string): { status: number; stdout: string; stderr: string } {

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 
@@ -48,7 +48,7 @@ const ALLOWED_PEB_NESTED_SUBCOMMANDS = new Map([
 ]);
 const READ_ONLY_GH_SUBCOMMANDS = new Map([["pr", new Set(["list", "view", "diff", "checks"])]]);
 export function createReviewCheckTool(root: string): ToolDefinition {
-  const reviewRoot = resolve(root);
+  const reviewRoot = resolveReviewRoot(root);
   return defineTool({
     name: "review_check",
     label: "review_check",
@@ -79,7 +79,7 @@ export function createReviewCheckTool(root: string): ToolDefinition {
 }
 
 export function planReviewCommand(command: string, root: string): ReviewCommandPlan {
-  const reviewRoot = resolve(root);
+  const reviewRoot = resolveReviewRoot(root);
   if (!command.trim()) throw new Error("review_check requires a command");
 
   const segments = splitCommandChain(command);
@@ -112,7 +112,7 @@ function normalizeCommand(argv: string[], cwd: string, root: string): ReviewStep
   }
 
   if (command === "git") return normalizeGitCommand(argv, cwd, root);
-  if (command === "peb") return normalizePebCommand(argv, cwd);
+  if (command === "peb") return normalizePebCommand(argv, cwd, root);
   if (command === "gh") return normalizeGhCommand(argv, cwd);
   if (command === "find") ensureFindIsReadOnly(argv);
   ensureFilesystemCommandPathsInsideRoot(argv, cwd, root);
@@ -149,16 +149,21 @@ function normalizeGitCommand(argv: string[], cwd: string, root: string): ReviewS
   return { argv: normalized, cwd: gitCwd, mode: "source" };
 }
 
-function normalizePebCommand(argv: string[], cwd: string): ReviewStep {
+function normalizePebCommand(argv: string[], cwd: string, root: string): ReviewStep {
   let index = 1;
   while (index < argv.length) {
     const arg = argv[index]!;
     if (arg === "--remote" || arg === "-R" || arg === "--repo") {
-      if (!argv[index + 1]) throw new Error(`${arg} requires a value`);
+      const value = argv[index + 1];
+      if (!value) throw new Error(`${arg} requires a value`);
+      ensurePebRepositoryOptionIsSafe(arg, value, cwd, root);
       index += 2;
       continue;
     }
     if (arg.startsWith("--remote=") || arg.startsWith("--repo=")) {
+      const [option, value] = splitLongOption(arg);
+      if (!value) throw new Error(`${option} requires a value`);
+      ensurePebRepositoryOptionIsSafe(option, value, cwd, root);
       index += 1;
       continue;
     }
@@ -176,11 +181,19 @@ function normalizePebCommand(argv: string[], cwd: string): ReviewStep {
 }
 
 function normalizeGhCommand(argv: string[], cwd: string): ReviewStep {
-  const area = argv[1];
-  const subcommand = argv[2];
+  let index = 1;
+  while (index < argv.length && argv[index]!.startsWith("-")) {
+    const arg = argv[index]!;
+    ensureGhOptionIsSafe(arg);
+    throw new Error(`review_check does not allow gh global option: ${arg}`);
+  }
+
+  const area = argv[index];
+  const subcommand = argv[index + 1];
   if (!area || !subcommand || !READ_ONLY_GH_SUBCOMMANDS.get(area)?.has(subcommand)) {
     throw new Error(`review_check does not allow gh command: ${argv.slice(1).join(" ") || "<missing>"}`);
   }
+  for (const arg of argv.slice(index + 2)) ensureGhOptionIsSafe(arg);
   return { argv, cwd, mode: "source" };
 }
 
@@ -246,7 +259,9 @@ function simpleFilesystemPathArguments(argv: string[], command: string): string[
     if (parsingOptions && arg.startsWith("-") && arg !== "-") {
       const valueOption = shortValueOption(command, arg);
       if (valueOption?.pathValue) {
-        paths.push(valueOption.value ?? argv[++i] ?? "");
+        const value = valueOption.value ?? argv[++i];
+        if (!value) throw new Error(`${arg} requires a path value`);
+        paths.push(value);
       } else if (valueOption && valueOption.value === undefined) {
         i++;
       }
@@ -439,7 +454,7 @@ function ensurePathArgumentInsideRoot(path: string, cwd: string, root: string): 
   const resolved = resolve(cwd, path);
   if (!isInside(root, resolved)) throw new Error(`review_check path escapes the worktree: ${path}`);
 
-  const real = realpathIfPresent(resolved);
+  const real = realpathForExistingPrefix(resolved);
   if (real && !isInside(realpathIfPresent(root) ?? root, real)) throw new Error(`review_check path escapes the worktree: ${path}`);
 }
 
@@ -454,6 +469,40 @@ function realpathIfPresent(path: string): string | undefined {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     throw error;
   }
+}
+
+function realpathForExistingPrefix(path: string): string | undefined {
+  const suffix: string[] = [];
+  let current = path;
+  while (true) {
+    const real = realpathIfPresent(current);
+    if (real) return suffix.length === 0 ? real : resolve(real, ...suffix.reverse());
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    suffix.push(basename(current));
+    current = parent;
+  }
+}
+
+function ensurePebRepositoryOptionIsSafe(option: string, value: string, cwd: string, root: string): void {
+  if (value.startsWith("~") || hasParentDirectorySegment(value) || isAbsolute(value)) {
+    throw new Error(`review_check does not allow peb ${option} path escapes: ${value}`);
+  }
+  if (/[\\/]/.test(value)) {
+    const resolved = resolve(cwd, value);
+    const real = realpathIfPresent(resolved) ?? resolved;
+    if (!isInside(root, real)) throw new Error(`review_check does not allow peb ${option} path escapes: ${value}`);
+    throw new Error(`review_check does not allow path-like peb ${option} values: ${value}`);
+  }
+}
+
+function ensureGhOptionIsSafe(arg: string): void {
+  const [option] = splitLongOption(arg);
+  if (option === "--repo" || option === "--web" || option === "--browser" || arg === "-R" || arg === "-w") {
+    throw new Error(`review_check does not allow gh option: ${arg}`);
+  }
+  if (arg.startsWith("-R") && arg !== "-R") throw new Error(`review_check does not allow gh option: ${arg}`);
+  if (arg.startsWith("-w") && arg !== "-w") throw new Error(`review_check does not allow gh option: ${arg}`);
 }
 
 function ensureGitSubcommandArgsReadOnly(argv: string[]): void {
@@ -498,20 +547,22 @@ function isGitOpenFilesInPagerShortOption(arg: string): boolean {
   return arg.startsWith("-") && !arg.startsWith("--") && arg.slice(1).includes("O");
 }
 
-function executeReviewCommandPlan(plan: ReviewCommandPlan, _root: string): { status: number; stdout: string; stderr: string } {
-  return executeSteps(plan.steps);
+function executeReviewCommandPlan(plan: ReviewCommandPlan, root: string): { status: number; stdout: string; stderr: string } {
+  return executeSteps(plan.steps, root);
 }
 
 function executeSteps(
   steps: ReviewStep[],
+  root: string,
 ): { status: number; stdout: string; stderr: string } {
   let stdout = "";
   let stderr = "";
 
   for (const step of steps) {
     const argv = step.argv[0] === "git" ? gitArgv(step.argv) : step.argv;
+    const cwd = ensureExecutionCwd(step.cwd, root);
     const result = spawnSync(argv[0]!, argv.slice(1), {
-      cwd: step.cwd,
+      cwd,
       encoding: "utf8",
       maxBuffer: 1024 * 1024 * 20,
       timeout: 10 * 60 * 1000,
@@ -519,8 +570,10 @@ function executeSteps(
     });
     stdout += result.stdout ?? "";
     stderr += result.stderr ?? "";
-    const status = result.status ?? (result.error ? 1 : 0);
-    if (status !== 0) return { status, stdout, stderr: stderr + (result.error ? String(result.error) : "") };
+    if (result.status === null) {
+      return { status: 1, stdout, stderr: stderr + formatSpawnFailure(result.error, result.signal) };
+    }
+    if (result.status !== 0) return { status: result.status, stdout, stderr: stderr + (result.error ? String(result.error) : "") };
   }
 
   return { status: 0, stdout, stderr };
@@ -571,11 +624,35 @@ function reviewCommandEnv(): NodeJS.ProcessEnv {
   };
 }
 
+function resolveReviewRoot(root: string): string {
+  return realpathSync.native(resolve(root));
+}
+
 function resolveReviewPath(root: string, cwd: string, path: string): string {
   if (path === "~" || path.startsWith("~/")) throw new Error("review_check paths must stay inside the worktree");
   const resolved = resolve(isAbsolute(path) ? path : join(cwd, path));
   if (!isInside(root, resolved)) throw new Error(`review_check path escapes the worktree: ${path}`);
-  return resolved;
+  let real: string;
+  try {
+    real = realpathSync.native(resolved);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new Error(`review_check path does not exist: ${path}`);
+    throw error;
+  }
+  if (!isInside(root, real)) throw new Error(`review_check path escapes the worktree: ${path}`);
+  return real;
+}
+
+function ensureExecutionCwd(cwd: string, root: string): string {
+  const realRoot = resolveReviewRoot(root);
+  const realCwd = realpathSync.native(cwd);
+  if (!isInside(realRoot, realCwd)) throw new Error(`review_check cwd escapes the worktree: ${cwd}`);
+  return realCwd;
+}
+
+function formatSpawnFailure(error: Error | undefined, signal: NodeJS.Signals | null): string {
+  const details = [signal ? `signal ${signal}` : undefined, error ? error.message : undefined].filter(Boolean).join("; ");
+  return details ? `spawn failed: ${details}` : "spawn failed with unknown termination";
 }
 
 function isInside(root: string, candidate: string): boolean {

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -128,6 +128,7 @@ function normalizeCommand(argv: string[], cwd: string, root: string): ReviewStep
   if (command === "grep") ensureGrepOptionsAreSafe(argv);
   if (command === "find") ensureFindIsReadOnly(argv);
   if (command === "ls") ensureLsOptionsAreSafe(argv);
+  if (command === "wc") ensureWcOptionsAreSafe(argv);
   ensureFilesystemCommandPathsInsideRoot(argv, cwd, root);
 
   return { argv, cwd, mode: "source" };
@@ -263,6 +264,8 @@ function ensureFindIsReadOnly(argv: string[]): void {
   ]);
   const unsafeTraversal = argv.find((arg) => FIND_SYMLINK_FOLLOW_OPTIONS.has(arg));
   if (unsafeTraversal) throw new Error(`review_check does not allow find option: ${unsafeTraversal}`);
+  const files0From = argv.find((arg) => arg === "-files0-from" || arg.startsWith("-files0-from="));
+  if (files0From) throw new Error(`review_check does not allow find option: ${files0From}`);
   const found = argv.find((arg) => forbiddenWriteActions.has(arg));
   if (found) throw new Error(`review_check does not allow find action: ${found}`);
 }
@@ -288,6 +291,24 @@ function ensureLsOptionsAreSafe(argv: string[]): void {
     }
 
     if (recursive && dereference) throw new Error("review_check does not allow ls recursive dereference options");
+  }
+}
+
+function ensureWcOptionsAreSafe(argv: string[]): void {
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--") break;
+
+    if (arg.startsWith("--") && arg !== "--") {
+      if (isLongOptionAbbreviation(arg, "--files0-from")) {
+        throw new Error(`review_check does not allow wc option: ${arg}`);
+      }
+      continue;
+    }
+
+    if (arg.startsWith("-") && arg !== "-" && arg.includes("0")) {
+      throw new Error(`review_check does not allow wc option: ${arg}`);
+    }
   }
 }
 
@@ -445,7 +466,7 @@ const GREP_VALUE_OPTIONS = new Set([
   "--label",
   "--max-count",
 ]);
-const FIND_PATH_VALUE_OPTIONS = new Set(["-anewer", "-cnewer", "-files0-from", "-newer", "-samefile"]);
+const FIND_PATH_VALUE_OPTIONS = new Set(["-anewer", "-cnewer", "-newer", "-samefile"]);
 
 function consumeGrepShortOptionsForSafety(
   arg: string,
@@ -649,6 +670,7 @@ function ensureNoGitWriteOptions(argv: string[]): void {
       arg.startsWith("--output=") ||
       isGitOptionAbbreviation(arg, "--ext-diff") ||
       isGitOptionAbbreviation(arg, "--textconv") ||
+      isGitOptionAbbreviation(arg, "--contents") ||
       arg === "--no-index" ||
       arg === "--exec" ||
       arg.startsWith("--exec=") ||
@@ -661,6 +683,11 @@ function ensureNoGitWriteOptions(argv: string[]): void {
 
 function isGitOptionAbbreviation(arg: string, fullOption: string): boolean {
   if (!arg.startsWith("--") || arg.startsWith("--no-")) return false;
+  return isLongOptionAbbreviation(arg, fullOption);
+}
+
+function isLongOptionAbbreviation(arg: string, fullOption: string): boolean {
+  if (!arg.startsWith("--")) return false;
   const optionName = arg.split("=", 1)[0]!;
   return optionName.length > 2 && fullOption.startsWith(optionName);
 }

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -37,7 +37,6 @@ const READ_ONLY_GIT_SUBCOMMANDS = new Set([
   "grep",
   "blame",
   "branch",
-  "describe",
   "merge-base",
 ]);
 const READ_ONLY_PEB_SUBCOMMANDS = new Set(["show", "list", "pr"]);

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -68,11 +68,11 @@ export function createReviewCheckTool(root: string): ToolDefinition {
     name: "review_check",
     label: "review_check",
     description:
-      "Run a restricted read-only review command. Git/Pebbles/GitHub inspection commands run in the worktree; build/test checks run in a disposable copy. Mutating commands, shell operators, redirects, commits, pushes, PR creation, and Pebbles writes are rejected.",
+      "Run a restricted read-only review command. Git/Pebbles/GitHub inspection commands run in the worktree; build/test checks run in a disposable copy. Mutating commands, shell operators, redirects, commits, pushes, PR creation, Pebbles writes, and copy-mode paths escaping the disposable copy are rejected.",
     promptSnippet: "Run allowlisted read-only review checks without granting a general shell",
     promptGuidelines: [
       "Use review_check instead of bash for git diff/log/status and project verification commands.",
-      "Do not attempt mutating commands; review_check rejects edits, commits, pushes, PR creation, and Pebbles writes.",
+      "Do not attempt mutating commands or output paths in the real worktree; review_check rejects edits, commits, pushes, PR creation, Pebbles writes, and copy-mode path escapes.",
     ],
     parameters: REVIEW_CHECK_PARAMETERS as any,
     async execute(_toolCallId, params: { command: string }) {
@@ -134,7 +134,10 @@ function normalizeCommand(argv: string[], cwd: string, root: string): ReviewStep
   if (command === "peb") return normalizePebCommand(argv, cwd);
   if (command === "gh") return normalizeGhCommand(argv, cwd);
   if (command === "find") ensureFindIsReadOnly(argv);
-  if (COPY_COMMANDS.has(command)) ensureCopyCommandAllowed(argv);
+  if (COPY_COMMANDS.has(command)) {
+    ensureCopyCommandAllowed(argv);
+    ensureCopyCommandArgsStayInCopy(argv);
+  }
 
   return { argv, cwd, mode: COPY_COMMANDS.has(command) ? "copy" : "source" };
 }
@@ -242,6 +245,27 @@ function ensureCopyCommandAllowed(argv: string[]): void {
 
 function isAllowedPackageScript(script: string): boolean {
   return PACKAGE_SCRIPTS.has(script) || /^(test|lint|build|check|typecheck|type-check)(:|$)/.test(script);
+}
+
+function ensureCopyCommandArgsStayInCopy(argv: string[]): void {
+  const unsafe = argv.find((arg) => argReferencesPathOutsideCopy(arg));
+  if (unsafe) {
+    throw new Error(`review_check copy-mode arguments must stay within the disposable copy: ${unsafe}`);
+  }
+}
+
+function argReferencesPathOutsideCopy(arg: string): boolean {
+  return argValueParts(arg).some((part) => isAbsolute(part) || hasParentPathSegment(part));
+}
+
+function argValueParts(arg: string): string[] {
+  const equalsIndex = arg.indexOf("=");
+  if (equalsIndex === -1) return [arg];
+  return [arg, arg.slice(equalsIndex + 1)].filter(Boolean);
+}
+
+function hasParentPathSegment(value: string): boolean {
+  return value.split(/[\\/]+/).includes("..");
 }
 
 function ensureFindIsReadOnly(argv: string[]): void {

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
@@ -114,6 +115,7 @@ function normalizeCommand(argv: string[], cwd: string, root: string): ReviewStep
   if (command === "peb") return normalizePebCommand(argv, cwd);
   if (command === "gh") return normalizeGhCommand(argv, cwd);
   if (command === "find") ensureFindIsReadOnly(argv);
+  ensureFilesystemCommandPathsInsideRoot(argv, cwd, root);
 
   return { argv, cwd, mode: "source" };
 }
@@ -196,6 +198,262 @@ function ensureFindIsReadOnly(argv: string[]): void {
   ]);
   const found = argv.find((arg) => forbiddenWriteActions.has(arg));
   if (found) throw new Error(`review_check does not allow find action: ${found}`);
+}
+
+function ensureFilesystemCommandPathsInsideRoot(argv: string[], cwd: string, root: string): void {
+  const command = argv[0]!;
+  if (command === "pwd") return;
+
+  const paths = filesystemPathArguments(argv);
+  for (const path of paths) {
+    ensurePathArgumentInsideRoot(path, cwd, root);
+  }
+}
+
+function filesystemPathArguments(argv: string[]): string[] {
+  const command = argv[0]!;
+  if (command === "grep") return grepPathArguments(argv);
+  if (command === "find") return findPathArguments(argv);
+  if (command === "ls" || command === "cat" || command === "head" || command === "tail" || command === "wc") {
+    return simpleFilesystemPathArguments(argv, command);
+  }
+  return [];
+}
+
+function simpleFilesystemPathArguments(argv: string[], command: string): string[] {
+  const paths: string[] = [];
+  let parsingOptions = true;
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (parsingOptions && arg === "--") {
+      parsingOptions = false;
+      continue;
+    }
+
+    if (parsingOptions && arg.startsWith("--") && arg !== "--") {
+      const [option, inlineValue] = splitLongOption(arg);
+      if (isPathValuedOption(command, option)) {
+        const value = inlineValue ?? argv[++i];
+        if (!value) throw new Error(`${option} requires a value`);
+        paths.push(value);
+        continue;
+      }
+      if (inlineValue === undefined && isValueOption(command, option)) i++;
+      continue;
+    }
+
+    if (parsingOptions && arg.startsWith("-") && arg !== "-") {
+      const valueOption = shortValueOption(command, arg);
+      if (valueOption?.pathValue) {
+        paths.push(valueOption.value ?? argv[++i] ?? "");
+      } else if (valueOption && valueOption.value === undefined) {
+        i++;
+      }
+      continue;
+    }
+
+    paths.push(arg);
+  }
+
+  return paths;
+}
+
+function grepPathArguments(argv: string[]): string[] {
+  const paths: string[] = [];
+  const positional: string[] = [];
+  let parsingOptions = true;
+  let hasExplicitPattern = false;
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (parsingOptions && arg === "--") {
+      parsingOptions = false;
+      continue;
+    }
+
+    if (parsingOptions && arg.startsWith("--") && arg !== "--") {
+      const [option, inlineValue] = splitLongOption(arg);
+      if (option === "--file" || option === "--exclude-from") {
+        const value = inlineValue ?? argv[++i];
+        if (!value) throw new Error(`${option} requires a value`);
+        paths.push(value);
+        if (option === "--file") hasExplicitPattern = true;
+        continue;
+      }
+      if (option === "--regexp") {
+        if (inlineValue === undefined) i++;
+        hasExplicitPattern = true;
+        continue;
+      }
+      if (inlineValue === undefined && GREP_VALUE_OPTIONS.has(option)) i++;
+      continue;
+    }
+
+    if (parsingOptions && arg.startsWith("-") && arg !== "-") {
+      const consumed = consumeGrepShortOptions(arg, argv, i, paths);
+      if (consumed.hasExplicitPattern) hasExplicitPattern = true;
+      i += consumed.extraArgs;
+      continue;
+    }
+
+    positional.push(arg);
+  }
+
+  paths.push(...(hasExplicitPattern ? positional : positional.slice(1)));
+  return paths;
+}
+
+function findPathArguments(argv: string[]): string[] {
+  const paths: string[] = [];
+  let i = 1;
+
+  for (; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (isFindExpressionStart(arg)) break;
+    paths.push(arg);
+  }
+
+  for (; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (FIND_PATH_VALUE_OPTIONS.has(arg)) {
+      const value = argv[++i];
+      if (!value) throw new Error(`${arg} requires a value`);
+      paths.push(value);
+    }
+  }
+
+  return paths;
+}
+
+const GREP_VALUE_OPTIONS = new Set([
+  "--after-context",
+  "--before-context",
+  "--binary-files",
+  "--context",
+  "--devices",
+  "--directories",
+  "--exclude",
+  "--exclude-dir",
+  "--group-separator",
+  "--include",
+  "--label",
+  "--max-count",
+]);
+const FIND_PATH_VALUE_OPTIONS = new Set(["-anewer", "-cnewer", "-files0-from", "-newer", "-samefile"]);
+
+function consumeGrepShortOptions(
+  arg: string,
+  argv: string[],
+  index: number,
+  paths: string[],
+): { extraArgs: number; hasExplicitPattern: boolean } {
+  let hasExplicitPattern = false;
+  const optionCharsWithValues = new Set(["A", "B", "C", "D", "d", "m"]);
+
+  for (let offset = 1; offset < arg.length; offset++) {
+    const option = arg[offset]!;
+    const rest = arg.slice(offset + 1);
+    if (option === "e" || option === "f") {
+      const value = rest || argv[index + 1];
+      if (!value) throw new Error(`-${option} requires a value`);
+      if (option === "f") paths.push(value);
+      hasExplicitPattern = true;
+      return { extraArgs: rest ? 0 : 1, hasExplicitPattern };
+    }
+    if (optionCharsWithValues.has(option)) return { extraArgs: rest ? 0 : 1, hasExplicitPattern };
+  }
+
+  return { extraArgs: 0, hasExplicitPattern };
+}
+
+function isFindExpressionStart(arg: string): boolean {
+  return arg.startsWith("-") || arg === "(" || arg === "!" || arg === ",";
+}
+
+function splitLongOption(arg: string): [string, string | undefined] {
+  const equalsIndex = arg.indexOf("=");
+  if (equalsIndex === -1) return [arg, undefined];
+  return [arg.slice(0, equalsIndex), arg.slice(equalsIndex + 1)];
+}
+
+function isPathValuedOption(command: string, option: string): boolean {
+  return command === "wc" && option === "--files0-from";
+}
+
+function isValueOption(command: string, option: string): boolean {
+  const optionsByCommand = new Map([
+    ["head", new Set(["--bytes", "--lines"])],
+    ["tail", new Set(["--bytes", "--lines", "--pid", "--sleep-interval"])],
+    [
+      "ls",
+      new Set([
+        "--block-size",
+        "--color",
+        "--format",
+        "--hide",
+        "--ignore",
+        "--indicator-style",
+        "--quoting-style",
+        "--sort",
+        "--tabsize",
+        "--time-style",
+        "--width",
+      ]),
+    ],
+  ]);
+  return optionsByCommand.get(command)?.has(option) ?? false;
+}
+
+function shortValueOption(command: string, arg: string): { value?: string; pathValue: boolean } | undefined {
+  const optionCharsByCommand = new Map([
+    ["head", new Set(["c", "n"])],
+    ["tail", new Set(["c", "n", "s"])],
+    ["ls", new Set(["I", "T", "w"])],
+  ]);
+  const pathOptionCharsByCommand = new Map([["wc", new Set(["0"])]]);
+  const pathOption = findShortOptionValue(arg, pathOptionCharsByCommand.get(command));
+  if (pathOption) return { value: pathOption.value, pathValue: true };
+  const value = findShortOptionValue(arg, optionCharsByCommand.get(command));
+  return value ? { value: value.value, pathValue: false } : undefined;
+}
+
+function findShortOptionValue(arg: string, optionChars: Set<string> | undefined): { value?: string } | undefined {
+  if (!optionChars) return undefined;
+  for (let offset = 1; offset < arg.length; offset++) {
+    const option = arg[offset]!;
+    if (!optionChars.has(option)) continue;
+    return { value: arg.slice(offset + 1) || undefined };
+  }
+  return undefined;
+}
+
+function ensurePathArgumentInsideRoot(path: string, cwd: string, root: string): void {
+  if (!path || path === "-") return;
+  if (path.startsWith("~")) throw new Error(`review_check does not allow home paths for filesystem command arguments: ${path}`);
+  if (isAbsolute(path)) throw new Error(`review_check does not allow absolute paths for filesystem command arguments: ${path}`);
+  if (hasParentDirectorySegment(path)) {
+    throw new Error(`review_check does not allow parent directory segments in filesystem command arguments: ${path}`);
+  }
+
+  const resolved = resolve(cwd, path);
+  if (!isInside(root, resolved)) throw new Error(`review_check path escapes the worktree: ${path}`);
+
+  const real = realpathIfPresent(resolved);
+  if (real && !isInside(realpathIfPresent(root) ?? root, real)) throw new Error(`review_check path escapes the worktree: ${path}`);
+}
+
+function hasParentDirectorySegment(path: string): boolean {
+  return path.split(/[\\/]+/).includes("..");
+}
+
+function realpathIfPresent(path: string): string | undefined {
+  try {
+    return realpathSync.native(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
 }
 
 function ensureGitSubcommandArgsReadOnly(argv: string[]): void {

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -47,6 +47,17 @@ const ALLOWED_PEB_NESTED_SUBCOMMANDS = new Map([
   ["closure", new Set(["show"])],
 ]);
 const READ_ONLY_GH_SUBCOMMANDS = new Map([["pr", new Set(["list", "view", "diff", "checks"])]]);
+const GREP_RECURSIVE_LONG_OPTIONS = new Set(["--recursive", "--dereference-recursive"]);
+const GREP_SHORT_VALUE_OPTION_CHARS = new Set(["A", "B", "C", "D", "d", "m"]);
+const FIND_SYMLINK_FOLLOW_OPTIONS = new Set(["-H", "-L", "-follow"]);
+const LS_RECURSIVE_LONG_OPTIONS = new Set(["--recursive"]);
+const LS_DEREFERENCE_LONG_OPTIONS = new Set([
+  "--dereference",
+  "--dereference-command-line",
+  "--dereference-command-line-symlink-to-dir",
+]);
+const LS_SHORT_VALUE_OPTION_CHARS = new Set(["I", "T", "w"]);
+
 export function createReviewCheckTool(root: string): ToolDefinition {
   const reviewRoot = resolveReviewRoot(root);
   return defineTool({
@@ -114,7 +125,9 @@ function normalizeCommand(argv: string[], cwd: string, root: string): ReviewStep
   if (command === "git") return normalizeGitCommand(argv, cwd, root);
   if (command === "peb") return normalizePebCommand(argv, cwd, root);
   if (command === "gh") return normalizeGhCommand(argv, cwd);
+  if (command === "grep") ensureGrepOptionsAreSafe(argv);
   if (command === "find") ensureFindIsReadOnly(argv);
+  if (command === "ls") ensureLsOptionsAreSafe(argv);
   ensureFilesystemCommandPathsInsideRoot(argv, cwd, root);
 
   return { argv, cwd, mode: "source" };
@@ -197,6 +210,45 @@ function normalizeGhCommand(argv: string[], cwd: string): ReviewStep {
   return { argv, cwd, mode: "source" };
 }
 
+function ensureGrepOptionsAreSafe(argv: string[]): void {
+  let parsingOptions = true;
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (parsingOptions && arg === "--") {
+      parsingOptions = false;
+      continue;
+    }
+    if (!parsingOptions) continue;
+
+    if (arg.startsWith("--") && arg !== "--") {
+      const [option, inlineValue] = splitLongOption(arg);
+      if (GREP_RECURSIVE_LONG_OPTIONS.has(option)) throw new Error(`review_check does not allow grep option: ${option}`);
+      if (option === "--directories") {
+        const value = inlineValue ?? argv[i + 1];
+        if (value === "recurse") {
+          const forbidden = inlineValue === undefined ? `${option} ${value}` : `${option}=${value}`;
+          throw new Error(`review_check does not allow grep option: ${forbidden}`);
+        }
+        if (inlineValue === undefined) i++;
+        continue;
+      }
+      if (option === "--file" || option === "--exclude-from" || option === "--regexp") {
+        if (inlineValue === undefined) i++;
+        continue;
+      }
+      if (inlineValue === undefined && GREP_VALUE_OPTIONS.has(option)) i++;
+      continue;
+    }
+
+    if (arg.startsWith("-") && arg !== "-") {
+      const consumed = consumeGrepShortOptionsForSafety(arg, argv, i);
+      if (consumed.forbidden) throw new Error(`review_check does not allow grep option: ${consumed.forbidden}`);
+      i += consumed.extraArgs;
+    }
+  }
+}
+
 function ensureFindIsReadOnly(argv: string[]): void {
   const forbiddenWriteActions = new Set([
     "-delete",
@@ -209,8 +261,34 @@ function ensureFindIsReadOnly(argv: string[]): void {
     "-ok",
     "-okdir",
   ]);
+  const unsafeTraversal = argv.find((arg) => FIND_SYMLINK_FOLLOW_OPTIONS.has(arg));
+  if (unsafeTraversal) throw new Error(`review_check does not allow find option: ${unsafeTraversal}`);
   const found = argv.find((arg) => forbiddenWriteActions.has(arg));
   if (found) throw new Error(`review_check does not allow find action: ${found}`);
+}
+
+function ensureLsOptionsAreSafe(argv: string[]): void {
+  let recursive = false;
+  let dereference = false;
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--") break;
+
+    if (arg.startsWith("--") && arg !== "--") {
+      const [option, inlineValue] = splitLongOption(arg);
+      recursive ||= LS_RECURSIVE_LONG_OPTIONS.has(option);
+      dereference ||= LS_DEREFERENCE_LONG_OPTIONS.has(option);
+      if (inlineValue === undefined && isValueOption("ls", option)) i++;
+    } else if (arg.startsWith("-") && arg !== "-") {
+      const consumed = consumeLsShortOptionsForSafety(arg);
+      recursive ||= consumed.recursive;
+      dereference ||= consumed.dereference;
+      i += consumed.extraArgs;
+    }
+
+    if (recursive && dereference) throw new Error("review_check does not allow ls recursive dereference options");
+  }
 }
 
 function ensureFilesystemCommandPathsInsideRoot(argv: string[], cwd: string, root: string): void {
@@ -325,6 +403,18 @@ function findPathArguments(argv: string[]): string[] {
 
   for (; i < argv.length; i++) {
     const arg = argv[i]!;
+    if (arg === "-P" || arg === "-H" || arg === "-L") continue;
+    if (arg === "-D") {
+      i++;
+      continue;
+    }
+    if (arg.startsWith("-D") || /^-O\d+$/.test(arg)) continue;
+    if (isFindExpressionStart(arg)) break;
+    break;
+  }
+
+  for (; i < argv.length; i++) {
+    const arg = argv[i]!;
     if (isFindExpressionStart(arg)) break;
     paths.push(arg);
   }
@@ -357,6 +447,45 @@ const GREP_VALUE_OPTIONS = new Set([
 ]);
 const FIND_PATH_VALUE_OPTIONS = new Set(["-anewer", "-cnewer", "-files0-from", "-newer", "-samefile"]);
 
+function consumeGrepShortOptionsForSafety(
+  arg: string,
+  argv: string[],
+  index: number,
+): { extraArgs: number; forbidden?: string } {
+  for (let offset = 1; offset < arg.length; offset++) {
+    const option = arg[offset]!;
+    const rest = arg.slice(offset + 1);
+    if (option === "r" || option === "R") return { extraArgs: 0, forbidden: `-${option}` };
+    if (option === "d") {
+      const value = rest || argv[index + 1];
+      if (value === "recurse") return { extraArgs: 0, forbidden: rest ? "-drecurse" : "-d recurse" };
+      return { extraArgs: rest ? 0 : 1 };
+    }
+    if (option === "e" || option === "f" || GREP_SHORT_VALUE_OPTION_CHARS.has(option)) {
+      return { extraArgs: rest ? 0 : 1 };
+    }
+  }
+
+  return { extraArgs: 0 };
+}
+
+function consumeLsShortOptionsForSafety(arg: string): { extraArgs: number; recursive: boolean; dereference: boolean } {
+  let recursive = false;
+  let dereference = false;
+
+  for (let offset = 1; offset < arg.length; offset++) {
+    const option = arg[offset]!;
+    const rest = arg.slice(offset + 1);
+    if (option === "R") recursive = true;
+    if (option === "H" || option === "L") dereference = true;
+    if (LS_SHORT_VALUE_OPTION_CHARS.has(option)) {
+      return { extraArgs: rest ? 0 : 1, recursive, dereference };
+    }
+  }
+
+  return { extraArgs: 0, recursive, dereference };
+}
+
 function consumeGrepShortOptions(
   arg: string,
   argv: string[],
@@ -364,7 +493,6 @@ function consumeGrepShortOptions(
   paths: string[],
 ): { extraArgs: number; hasExplicitPattern: boolean } {
   let hasExplicitPattern = false;
-  const optionCharsWithValues = new Set(["A", "B", "C", "D", "d", "m"]);
 
   for (let offset = 1; offset < arg.length; offset++) {
     const option = arg[offset]!;
@@ -376,7 +504,7 @@ function consumeGrepShortOptions(
       hasExplicitPattern = true;
       return { extraArgs: rest ? 0 : 1, hasExplicitPattern };
     }
-    if (optionCharsWithValues.has(option)) return { extraArgs: rest ? 0 : 1, hasExplicitPattern };
+    if (GREP_SHORT_VALUE_OPTION_CHARS.has(option)) return { extraArgs: rest ? 0 : 1, hasExplicitPattern };
   }
 
   return { extraArgs: 0, hasExplicitPattern };

--- a/pi/picastle/review-tools.mts
+++ b/pi/picastle/review-tools.mts
@@ -217,6 +217,10 @@ function ensureNoGitWriteOptions(argv: string[]): void {
       arg === "--no-index" ||
       arg === "--exec" ||
       arg.startsWith("--exec=") ||
+      arg === "--open-files-in-pager" ||
+      arg.startsWith("--open-files-in-pager=") ||
+      arg === "-O" ||
+      arg.startsWith("-O") ||
       arg === "-o",
   );
   if (forbidden) throw new Error(`review_check does not allow git option: ${forbidden}`);

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -60,6 +60,12 @@ test("rejects git helper execution options", () => {
   assert.throws(() => planReviewCommand("git diff --textco", root), /git option: --textco/);
 });
 
+test("rejects git describe because dirty and broken modes refresh the index", () => {
+  assert.throws(() => planReviewCommand("git describe", root), /git subcommand: describe/);
+  assert.throws(() => planReviewCommand("git describe --dirty --always", root), /git subcommand: describe/);
+  assert.throws(() => planReviewCommand("git describe --broken", root), /git subcommand: describe/);
+});
+
 test("rejects commands that are not on the review allowlist", () => {
   assert.throws(() => planReviewCommand("touch pwned", root), /does not allow command: touch/);
   assert.throws(() => planReviewCommand("rg --pre rm pattern file", root), /does not allow command: rg/);

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import { createReviewCheckTool, planReviewCommand } from "./review-tools.mts";
+
+const root = resolve(process.cwd(), "../..");
+
+test("allows read-only git inspection commands", () => {
+  const plan = planReviewCommand("git diff --stat main...HEAD", root);
+  assert.equal(plan.mode, "source");
+  assert.deepEqual(plan.steps[0]?.argv, ["git", "diff", "--stat", "main...HEAD"]);
+});
+
+test("allows cd before disposable package checks", () => {
+  const plan = planReviewCommand("cd pi/picastle && npm run typecheck", root);
+  assert.equal(plan.mode, "copy");
+  assert.match(plan.steps[0]?.cwd ?? "", /pi[\/]picastle$/);
+  assert.deepEqual(plan.steps[0]?.argv, ["npm", "run", "typecheck"]);
+});
+
+test("allows read-only Pebbles inspection with remote args", () => {
+  const plan = planReviewCommand("peb --remote pi -R dotfiles show dotfiles-evh --json", root);
+  assert.equal(plan.mode, "source");
+});
+
+test("rejects shell redirection and chained mutations", () => {
+  assert.throws(() => planReviewCommand("git diff > review.patch", root), /shell operator/);
+  assert.throws(() => planReviewCommand("git diff && git push", root), /git subcommand: push/);
+});
+
+test("rejects mutating git, gh, and Pebbles commands", () => {
+  assert.throws(() => planReviewCommand("git commit -am nope", root), /git subcommand: commit/);
+  assert.throws(() => planReviewCommand("git branch scratch", root), /git branch argument: scratch/);
+  assert.throws(() => planReviewCommand("gh pr create --fill", root), /gh command/);
+  assert.throws(() => planReviewCommand("peb update dotfiles-evh --status closed", root), /peb subcommand: update/);
+});
+
+test("rejects commands that are not on the review allowlist", () => {
+  assert.throws(() => planReviewCommand("touch pwned", root), /does not allow command: touch/);
+  assert.throws(() => planReviewCommand("npm install", root), /only allows npm test/);
+});
+
+test("rejects paths that escape the worktree", () => {
+  assert.throws(() => planReviewCommand("cd .. && npm test", root), /escapes the worktree/);
+  assert.throws(() => planReviewCommand("git -C /tmp status", root), /escapes the worktree/);
+});
+
+test("custom tool executes allowed source inspection", async () => {
+  const tool = createReviewCheckTool(root);
+  const result = await tool.execute("test", { command: "git status --short" } as never, undefined, undefined, {} as never);
+  assert.match(result.content[0]?.type === "text" ? result.content[0].text ?? "" : "", /\$ git status --short/);
+});

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -39,6 +39,13 @@ test("rejects mutating git, gh, and Pebbles commands", () => {
   assert.throws(() => planReviewCommand("peb update dotfiles-evh --status closed", root), /peb subcommand: update/);
 });
 
+test("rejects git grep pager execution options", () => {
+  assert.throws(() => planReviewCommand("git grep --open-files-in-pager=touch needle", root), /git option: --open-files-in-pager=touch/);
+  assert.throws(() => planReviewCommand("git grep --open-files-in-pager touch needle", root), /git option: --open-files-in-pager/);
+  assert.throws(() => planReviewCommand("git grep -Otouch needle", root), /git option: -Otouch/);
+  assert.throws(() => planReviewCommand("git grep -O touch needle", root), /git option: -O/);
+});
+
 test("rejects commands that are not on the review allowlist", () => {
   assert.throws(() => planReviewCommand("touch pwned", root), /does not allow command: touch/);
   assert.throws(() => planReviewCommand("rg --pre rm pattern file", root), /does not allow command: rg/);

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import test from "node:test";
 
 import { createReviewCheckTool, planReviewCommand } from "./review-tools.mts";
@@ -39,6 +42,7 @@ test("rejects mutating git, gh, and Pebbles commands", () => {
 test("rejects commands that are not on the review allowlist", () => {
   assert.throws(() => planReviewCommand("touch pwned", root), /does not allow command: touch/);
   assert.throws(() => planReviewCommand("npm install", root), /only allows npm test/);
+  assert.throws(() => planReviewCommand("rg --pre rm pattern file", root), /does not allow command: rg/);
 });
 
 test("rejects paths that escape the worktree", () => {
@@ -70,3 +74,28 @@ test("custom tool executes allowed source inspection", async () => {
   const result = await tool.execute("test", { command: "git status --short" } as never, undefined, undefined, {} as never);
   assert.match(result.content[0]?.type === "text" ? result.content[0].text ?? "" : "", /\$ git status --short/);
 });
+
+test("source git status does not refresh the index", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-index-"));
+  try {
+    runGit(repo, "init");
+    writeFileSync(join(repo, "tracked.txt"), "original\n");
+    runGit(repo, "add", "tracked.txt");
+    const indexPath = join(repo, ".git", "index");
+    const before = statSync(indexPath, { bigint: true }).mtimeNs;
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    const tool = createReviewCheckTool(repo);
+    await tool.execute("test", { command: "git status --short" } as never, undefined, undefined, {} as never);
+
+    const after = statSync(indexPath, { bigint: true }).mtimeNs;
+    assert.equal(after, before);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+function runGit(cwd: string, ...args: string[]): void {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+}

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -37,6 +37,12 @@ test("allows read-only Pebbles inspection with remote args", () => {
   assert.equal(plan.mode, "source");
 });
 
+test("rejects path-like Pebbles repo and remote options", () => {
+  assert.throws(() => planReviewCommand("peb -R /tmp show dotfiles-evh", root), /peb -R path escapes/);
+  assert.throws(() => planReviewCommand("peb --repo ../outside show dotfiles-evh", root), /peb --repo path escapes/);
+  assert.throws(() => planReviewCommand("peb --remote=../outside show dotfiles-evh", root), /peb --remote path escapes/);
+});
+
 test("allows git grep pathspec separator", () => {
   const plan = planReviewCommand("git grep needle -- pi/picastle/README.md", root);
   assert.deepEqual(plan.steps[0]?.argv, ["git", "grep", "needle", "--", "pi/picastle/README.md"]);
@@ -51,6 +57,9 @@ test("rejects mutating git, gh, and Pebbles commands", () => {
   assert.throws(() => planReviewCommand("git commit -am nope", root), /git subcommand: commit/);
   assert.throws(() => planReviewCommand("git branch scratch", root), /git branch argument: scratch/);
   assert.throws(() => planReviewCommand("gh pr create --fill", root), /gh command/);
+  assert.throws(() => planReviewCommand("gh pr view --web", root), /gh option: --web/);
+  assert.throws(() => planReviewCommand("gh --repo owner/repo pr view 1", root), /gh option: --repo/);
+  assert.throws(() => planReviewCommand("gh pr view 1 --repo owner/repo", root), /gh option: --repo/);
   assert.throws(() => planReviewCommand("peb update dotfiles-evh --status closed", root), /peb subcommand: update/);
 });
 
@@ -106,6 +115,22 @@ test("rejects paths that escape the worktree", () => {
   assert.throws(() => planReviewCommand("git -C /tmp status", root), /escapes the worktree/);
 });
 
+test("rejects symlink escapes for cd, git -C, and filesystem arguments", () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-symlink-"));
+  const outside = mkdtempSync(join(tmpdir(), "picastle-review-outside-"));
+  try {
+    symlinkSync(outside, join(repo, "outside-link"));
+    assert.throws(() => planReviewCommand("cd outside-link && pwd", repo), /escapes the worktree/);
+    assert.throws(() => planReviewCommand("git -C outside-link status", repo), /escapes the worktree/);
+    assert.throws(() => planReviewCommand("find outside-link -maxdepth 1 -type f -print", repo), /escapes the worktree/);
+    assert.throws(() => planReviewCommand("grep -f outside-link/patterns.txt needle file.txt", repo), /escapes the worktree/);
+    assert.throws(() => planReviewCommand("wc --files0-from outside-link/files.txt", repo), /escapes the worktree/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
 test("confines filesystem command path arguments to the worktree", () => {
   assert.throws(() => planReviewCommand("cat /tmp/x", root), /absolute paths/);
   assert.throws(() => planReviewCommand("cat ~/.foo", root), /home paths/);
@@ -114,6 +139,15 @@ test("confines filesystem command path arguments to the worktree", () => {
 
   const plan = planReviewCommand("cat pi/picastle/package.json", root);
   assert.deepEqual(plan.steps[0]?.argv, ["cat", "pi/picastle/package.json"]);
+});
+
+test("confines path-valued options for find, grep, and wc", () => {
+  assert.throws(() => planReviewCommand("find . -newer /tmp/reference", root), /absolute paths/);
+  assert.throws(() => planReviewCommand("find . -files0-from ../files", root), /parent directory/);
+  assert.throws(() => planReviewCommand("grep --exclude-from /tmp/patterns needle .", root), /absolute paths/);
+  assert.throws(() => planReviewCommand("grep -f ../patterns needle .", root), /parent directory/);
+  assert.throws(() => planReviewCommand("wc --files0-from /tmp/files", root), /absolute paths/);
+  assert.throws(() => planReviewCommand("wc -0 ../files", root), /parent directory/);
 });
 
 test("rejects write-capable find actions", () => {
@@ -133,6 +167,25 @@ test("custom tool executes allowed source inspection", async () => {
   const tool = createReviewCheckTool(root);
   const result = await tool.execute("test", { command: "git status --short" } as never, undefined, undefined, {} as never);
   assert.match(result.content[0]?.type === "text" ? result.content[0].text ?? "" : "", /\$ git status --short/);
+});
+
+test("custom tool treats signal termination as failure", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-signal-"));
+  const bin = mkdtempSync(join(tmpdir(), "picastle-review-bin-"));
+  const oldPath = process.env.PATH;
+  try {
+    writeExecutable(join(bin, "git"), "#!/bin/sh\nkill -TERM $$\nsleep 1\n");
+    process.env.PATH = `${bin}:${oldPath ?? ""}`;
+    const tool = createReviewCheckTool(repo);
+    await assert.rejects(
+      () => tool.execute("test", { command: "git status --short" } as never, undefined, undefined, {} as never),
+      /signal SIGTERM/,
+    );
+  } finally {
+    process.env.PATH = oldPath;
+    rmSync(bin, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
 });
 
 test("reviewer session setup does not load project-local Pi extensions", async () => {
@@ -169,7 +222,7 @@ test("reviewer session setup does not load project-local Pi extensions", async (
     const { session, extensionsResult } = await createAgentSession({
       cwd: repo,
       agentDir,
-      tools: ["read", "grep", "find", "ls", "review_check"],
+      tools: ["review_check"],
       customTools: [createReviewCheckTool(repo)],
       authStorage,
       modelRegistry: ModelRegistry.create(authStorage, join(agentDir, "models.json")),
@@ -182,6 +235,8 @@ test("reviewer session setup does not load project-local Pi extensions", async (
       assert.equal(extensionsResult.extensions.length, 0);
       assert.equal(existsSync(pwnedOnLoad), false);
       assert.equal(existsSync(pwnedOnSessionStart), false);
+      assert.deepEqual(session.getActiveToolNames(), ["review_check"]);
+      assert.equal(session.getAllTools().some((tool) => ["read", "grep", "find", "ls"].includes(tool.name)), false);
     } finally {
       session.dispose();
     }

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -46,6 +46,25 @@ test("rejects paths that escape the worktree", () => {
   assert.throws(() => planReviewCommand("git -C /tmp status", root), /escapes the worktree/);
 });
 
+test("rejects disposable-copy checks that target the source worktree", () => {
+  assert.throws(
+    () => planReviewCommand(`python -m pytest --junitxml ${root}/pytest.xml`, root),
+    /copy-mode arguments must stay within the disposable copy/,
+  );
+  assert.throws(
+    () => planReviewCommand(`cargo build --target-dir ${root}/target-review`, root),
+    /copy-mode arguments must stay within the disposable copy/,
+  );
+  assert.throws(
+    () => planReviewCommand(`npm run test -- --output=${root}/review-output.txt`, root),
+    /copy-mode arguments must stay within the disposable copy/,
+  );
+  assert.throws(
+    () => planReviewCommand("pytest --junitxml ../pytest.xml", root),
+    /copy-mode arguments must stay within the disposable copy/,
+  );
+});
+
 test("custom tool executes allowed source inspection", async () => {
   const tool = createReviewCheckTool(root);
   const result = await tool.execute("test", { command: "git status --short" } as never, undefined, undefined, {} as never);

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -131,6 +131,30 @@ test("rejects symlink escapes for cd, git -C, and filesystem arguments", () => {
   }
 });
 
+test("rejects recursive symlink-following filesystem options", () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-recursive-symlink-"));
+  const outside = mkdtempSync(join(tmpdir(), "picastle-review-recursive-outside-"));
+  try {
+    writeFileSync(join(outside, "secret.txt"), "outside\n");
+    symlinkSync(outside, join(repo, "outside-link"));
+
+    assert.throws(() => planReviewCommand("grep -R outside .", repo), /grep option: -R/);
+    assert.throws(() => planReviewCommand("grep -r outside .", repo), /grep option: -r/);
+    assert.throws(() => planReviewCommand("grep --recursive outside .", repo), /grep option: --recursive/);
+    assert.throws(() => planReviewCommand("grep --dereference-recursive outside .", repo), /grep option: --dereference-recursive/);
+    assert.throws(() => planReviewCommand("grep --directories=recurse outside .", repo), /grep option: --directories=recurse/);
+    assert.throws(() => planReviewCommand("grep -d recurse outside .", repo), /grep option: -d recurse/);
+    assert.throws(() => planReviewCommand("find -L . -name secret.txt -print", repo), /find option: -L/);
+    assert.throws(() => planReviewCommand("find . -follow -name secret.txt -print", repo), /find option: -follow/);
+    assert.throws(() => planReviewCommand("ls -LR .", repo), /ls recursive dereference options/);
+    assert.throws(() => planReviewCommand("ls -R -L .", repo), /ls recursive dereference options/);
+    assert.throws(() => planReviewCommand("ls --recursive --dereference .", repo), /ls recursive dereference options/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
 test("confines filesystem command path arguments to the worktree", () => {
   assert.throws(() => planReviewCommand("cat /tmp/x", root), /absolute paths/);
   assert.throws(() => planReviewCommand("cat ~/.foo", root), /home paths/);

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -14,7 +14,7 @@ import {
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 
-import { createReviewerResourceLoader } from "./review-session.mts";
+import { createReviewerAgentTooling, createReviewerResourceLoader } from "./review-session.mts";
 import { createReviewCheckTool, planReviewCommand } from "./review-tools.mts";
 
 const root = resolve(process.cwd(), "../..");
@@ -41,6 +41,17 @@ test("rejects path-like Pebbles repo and remote options", () => {
   assert.throws(() => planReviewCommand("peb -R /tmp show dotfiles-evh", root), /peb -R path escapes/);
   assert.throws(() => planReviewCommand("peb --repo ../outside show dotfiles-evh", root), /peb --repo path escapes/);
   assert.throws(() => planReviewCommand("peb --remote=../outside show dotfiles-evh", root), /peb --remote path escapes/);
+});
+
+test("validates Pebbles repo and remote options after subcommands", () => {
+  assert.doesNotThrow(() => planReviewCommand("peb list --repo dotfiles --json", root));
+  assert.doesNotThrow(() => planReviewCommand("peb dep list dotfiles-evh --remote origin", root));
+  assert.doesNotThrow(() => planReviewCommand("peb comment list dotfiles-evh -Rdotfiles", root));
+
+  assert.throws(() => planReviewCommand("peb list --repo ../outside", root), /peb --repo path escapes/);
+  assert.throws(() => planReviewCommand("peb dep list dotfiles-evh --remote /tmp", root), /peb --remote path escapes/);
+  assert.throws(() => planReviewCommand("peb comment list dotfiles-evh -R ../outside", root), /peb -R path escapes/);
+  assert.throws(() => planReviewCommand("peb pr --remote", root), /--remote requires a value/);
 });
 
 test("allows git grep pathspec separator", () => {
@@ -77,6 +88,13 @@ test("rejects git helper execution options", () => {
   assert.throws(() => planReviewCommand("git diff --ext", root), /git option: --ext/);
   assert.throws(() => planReviewCommand("git diff --textconv", root), /git option: --textconv/);
   assert.throws(() => planReviewCommand("git diff --textco", root), /git option: --textco/);
+});
+
+test("rejects git signature verification options and long-option abbreviations", () => {
+  assert.throws(() => planReviewCommand("git log --show-signature", root), /git option: --show-signature/);
+  assert.throws(() => planReviewCommand("git log --show-sign", root), /git option: --show-sign/);
+  assert.throws(() => planReviewCommand("git show --show-sig HEAD", root), /git option: --show-sig/);
+  assert.throws(() => planReviewCommand("git blame --show-signat -- pi/picastle/review-tools.mts", root), /git option: --show-signat/);
 });
 
 test("rejects git blame contents files and long-option abbreviations", () => {
@@ -232,6 +250,13 @@ test("custom tool treats signal termination as failure", async () => {
   }
 });
 
+test("reviewer agent tooling is wired to only review_check with extensions disabled", () => {
+  const tooling = createReviewerAgentTooling(root);
+  assert.deepEqual(tooling.tools, ["review_check"]);
+  assert.equal(tooling.disableExtensions, true);
+  assert.deepEqual(tooling.customTools.map((tool) => tool.name), ["review_check"]);
+});
+
 test("reviewer session setup does not load project-local Pi extensions", async () => {
   const repo = mkdtempSync(join(tmpdir(), "picastle-review-extension-"));
   const agentDir = mkdtempSync(join(tmpdir(), "picastle-review-agent-"));
@@ -328,6 +353,23 @@ test("source git status disables configured fsmonitor helpers", async () => {
   }
 });
 
+test("source git log disables configured signature verification helpers", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-signature-"));
+  try {
+    createFakeSignedCommit(repo);
+    writeExecutable(join(repo, ".git", "gpg.sh"), "#!/bin/sh\ntouch \"$PWD/pwned-gpg\"\nexit 1\n");
+    runGit(repo, "config", "log.showSignature", "true");
+    runGit(repo, "config", "gpg.program", ".git/gpg.sh");
+
+    const tool = createReviewCheckTool(repo);
+    await tool.execute("test", { command: "git log -1 --format=%H" } as never, undefined, undefined, {} as never);
+
+    assert.equal(existsSync(join(repo, "pwned-gpg")), false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 test("source git diff disables configured external diff and textconv helpers", async () => {
   const repo = mkdtempSync(join(tmpdir(), "picastle-review-diff-helpers-"));
   try {
@@ -354,6 +396,35 @@ test("source git diff disables configured external diff and textconv helpers", a
 function runGit(cwd: string, ...args: string[]): void {
   const result = spawnSync("git", args, { cwd, encoding: "utf8" });
   assert.equal(result.status, 0, result.stderr);
+}
+
+function createFakeSignedCommit(repo: string): void {
+  runGit(repo, "init");
+  runGit(repo, "config", "user.name", "Test User");
+  runGit(repo, "config", "user.email", "test@example.com");
+  writeFileSync(join(repo, "tracked.txt"), "original\n");
+  runGit(repo, "add", "tracked.txt");
+  const tree = spawnSync("git", ["write-tree"], { cwd: repo, encoding: "utf8" }).stdout.trim();
+  assert.match(tree, /^[0-9a-f]{40,}$/);
+  writeFileSync(
+    join(repo, "commit.txt"),
+    [
+      `tree ${tree}`,
+      "author Test User <test@example.com> 0 +0000",
+      "committer Test User <test@example.com> 0 +0000",
+      "gpgsig -----BEGIN PGP SIGNATURE-----",
+      " Version: fake",
+      " ",
+      " fake",
+      " -----END PGP SIGNATURE-----",
+      "",
+      "signed-ish",
+      "",
+    ].join("\n"),
+  );
+  const commit = spawnSync("git", ["hash-object", "-t", "commit", "-w", "commit.txt"], { cwd: repo, encoding: "utf8" }).stdout.trim();
+  assert.match(commit, /^[0-9a-f]{40,}$/);
+  runGit(repo, "update-ref", "HEAD", commit);
 }
 
 function writeExecutable(path: string, content: string): void {

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -79,6 +79,16 @@ test("rejects git helper execution options", () => {
   assert.throws(() => planReviewCommand("git diff --textco", root), /git option: --textco/);
 });
 
+test("rejects git blame contents files and long-option abbreviations", () => {
+  assert.throws(() => planReviewCommand("git blame --contents pi/picastle/README.md -- pi/picastle/review-tools.mts", root), /git option: --contents/);
+  assert.throws(() => planReviewCommand("git blame --contents=pi/picastle/README.md -- pi/picastle/review-tools.mts", root), /git option: --contents=/);
+  assert.throws(() => planReviewCommand("git blame --content=pi/picastle/README.md -- pi/picastle/review-tools.mts", root), /git option: --content=/);
+  assert.throws(() => planReviewCommand("git blame --cont pi/picastle/README.md -- pi/picastle/review-tools.mts", root), /git option: --cont/);
+
+  const plan = planReviewCommand("git blame -- pi/picastle/review-tools.mts", root);
+  assert.deepEqual(plan.steps[0]?.argv, ["git", "blame", "--", "pi/picastle/review-tools.mts"]);
+});
+
 test("rejects git describe because dirty and broken modes refresh the index", () => {
   assert.throws(() => planReviewCommand("git describe", root), /git subcommand: describe/);
   assert.throws(() => planReviewCommand("git describe --dirty --always", root), /git subcommand: describe/);
@@ -124,7 +134,6 @@ test("rejects symlink escapes for cd, git -C, and filesystem arguments", () => {
     assert.throws(() => planReviewCommand("git -C outside-link status", repo), /escapes the worktree/);
     assert.throws(() => planReviewCommand("find outside-link -maxdepth 1 -type f -print", repo), /escapes the worktree/);
     assert.throws(() => planReviewCommand("grep -f outside-link/patterns.txt needle file.txt", repo), /escapes the worktree/);
-    assert.throws(() => planReviewCommand("wc --files0-from outside-link/files.txt", repo), /escapes the worktree/);
   } finally {
     rmSync(repo, { recursive: true, force: true });
     rmSync(outside, { recursive: true, force: true });
@@ -165,13 +174,24 @@ test("confines filesystem command path arguments to the worktree", () => {
   assert.deepEqual(plan.steps[0]?.argv, ["cat", "pi/picastle/package.json"]);
 });
 
-test("confines path-valued options for find, grep, and wc", () => {
+test("confines path-valued options for find and grep", () => {
   assert.throws(() => planReviewCommand("find . -newer /tmp/reference", root), /absolute paths/);
-  assert.throws(() => planReviewCommand("find . -files0-from ../files", root), /parent directory/);
   assert.throws(() => planReviewCommand("grep --exclude-from /tmp/patterns needle .", root), /absolute paths/);
   assert.throws(() => planReviewCommand("grep -f ../patterns needle .", root), /parent directory/);
-  assert.throws(() => planReviewCommand("wc --files0-from /tmp/files", root), /absolute paths/);
-  assert.throws(() => planReviewCommand("wc -0 ../files", root), /parent directory/);
+});
+
+test("rejects files0-from list-file options even when the list file is inside the worktree", () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-files0-"));
+  try {
+    writeFileSync(join(repo, "files0.txt"), "/tmp/outside\0inside.txt\0");
+
+    assert.throws(() => planReviewCommand("find -files0-from files0.txt -print", repo), /find option: -files0-from/);
+    assert.throws(() => planReviewCommand("wc --files0-from files0.txt", repo), /wc option: --files0-from/);
+    assert.throws(() => planReviewCommand("wc --files0-from=files0.txt", repo), /wc option: --files0-from=/);
+    assert.throws(() => planReviewCommand("wc -0 files0.txt", repo), /wc option: -0/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
 });
 
 test("rejects write-capable find actions", () => {

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -27,6 +27,11 @@ test("allows read-only Pebbles inspection with remote args", () => {
   assert.equal(plan.mode, "source");
 });
 
+test("allows git grep pathspec separator", () => {
+  const plan = planReviewCommand("git grep needle -- pi/picastle/README.md", root);
+  assert.deepEqual(plan.steps[0]?.argv, ["git", "grep", "needle", "--", "pi/picastle/README.md"]);
+});
+
 test("rejects shell redirection and chained mutations", () => {
   assert.throws(() => planReviewCommand("git diff > review.patch", root), /shell operator/);
   assert.throws(() => planReviewCommand("git diff && git push", root), /git subcommand: push/);
@@ -44,6 +49,8 @@ test("rejects git grep pager execution options", () => {
   assert.throws(() => planReviewCommand("git grep --open-files-in-pager touch needle", root), /git option: --open-files-in-pager/);
   assert.throws(() => planReviewCommand("git grep -Otouch needle", root), /git option: -Otouch/);
   assert.throws(() => planReviewCommand("git grep -O touch needle", root), /git option: -O/);
+  assert.throws(() => planReviewCommand("git grep -nOfalse needle", root), /git option: -nOfalse/);
+  assert.throws(() => planReviewCommand("git grep --open-files-in-page=false needle", root), /git option: --open-files-in-page=false/);
 });
 
 test("rejects commands that are not on the review allowlist", () => {

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -106,6 +106,16 @@ test("rejects paths that escape the worktree", () => {
   assert.throws(() => planReviewCommand("git -C /tmp status", root), /escapes the worktree/);
 });
 
+test("confines filesystem command path arguments to the worktree", () => {
+  assert.throws(() => planReviewCommand("cat /tmp/x", root), /absolute paths/);
+  assert.throws(() => planReviewCommand("cat ~/.foo", root), /home paths/);
+  assert.throws(() => planReviewCommand("grep x ../file", root), /parent directory/);
+  assert.throws(() => planReviewCommand("find /tmp", root), /absolute paths/);
+
+  const plan = planReviewCommand("cat pi/picastle/package.json", root);
+  assert.deepEqual(plan.steps[0]?.argv, ["cat", "pi/picastle/package.json"]);
+});
+
 test("rejects write-capable find actions", () => {
   assert.throws(() => planReviewCommand("find . -delete", root), /find action: -delete/);
   assert.throws(() => planReviewCommand("find . -exec rm {} ;", root), /shell operator/);

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -51,6 +51,13 @@ test("rejects git grep pager execution options", () => {
   assert.throws(() => planReviewCommand("git grep -O touch needle", root), /git option: -O/);
   assert.throws(() => planReviewCommand("git grep -nOfalse needle", root), /git option: -nOfalse/);
   assert.throws(() => planReviewCommand("git grep --open-files-in-page=false needle", root), /git option: --open-files-in-page=false/);
+});
+
+test("rejects git helper execution options", () => {
+  assert.throws(() => planReviewCommand("git diff --ext-diff", root), /git option: --ext-diff/);
+  assert.throws(() => planReviewCommand("git diff --ext", root), /git option: --ext/);
+  assert.throws(() => planReviewCommand("git diff --textconv", root), /git option: --textconv/);
+  assert.throws(() => planReviewCommand("git diff --textco", root), /git option: --textco/);
 });
 
 test("rejects commands that are not on the review allowlist", () => {
@@ -122,7 +129,53 @@ test("source git status does not refresh the index", async () => {
   }
 });
 
+test("source git status disables configured fsmonitor helpers", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-fsmonitor-"));
+  try {
+    runGit(repo, "init");
+    writeFileSync(join(repo, "tracked.txt"), "original\n");
+    runGit(repo, "add", "tracked.txt");
+    writeExecutable(join(repo, ".git", "fsmonitor.sh"), "#!/bin/sh\ntouch \"$PWD/pwned-fsmonitor\"\nprintf '\\n'\n");
+    runGit(repo, "config", "core.fsmonitor", ".git/fsmonitor.sh");
+
+    const tool = createReviewCheckTool(repo);
+    await tool.execute("test", { command: "git status --short" } as never, undefined, undefined, {} as never);
+
+    assert.equal(existsSync(join(repo, "pwned-fsmonitor")), false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("source git diff disables configured external diff and textconv helpers", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-diff-helpers-"));
+  try {
+    runGit(repo, "init");
+    writeFileSync(join(repo, ".gitattributes"), "*.pwn diff=pwn\n");
+    writeFileSync(join(repo, "file.pwn"), "original\n");
+    runGit(repo, "add", ".gitattributes", "file.pwn");
+    writeExecutable(join(repo, ".git", "external-diff.sh"), "#!/bin/sh\ntouch \"$PWD/pwned-extdiff\"\nexit 0\n");
+    writeExecutable(join(repo, ".git", "textconv.sh"), "#!/bin/sh\ntouch \"$PWD/pwned-textconv\"\ncat \"$1\"\n");
+    runGit(repo, "config", "diff.pwn.command", ".git/external-diff.sh");
+    runGit(repo, "config", "diff.pwn.textconv", ".git/textconv.sh");
+    writeFileSync(join(repo, "file.pwn"), "changed\n");
+
+    const tool = createReviewCheckTool(repo);
+    await tool.execute("test", { command: "git diff" } as never, undefined, undefined, {} as never);
+
+    assert.equal(existsSync(join(repo, "pwned-extdiff")), false);
+    assert.equal(existsSync(join(repo, "pwned-textconv")), false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 function runGit(cwd: string, ...args: string[]): void {
   const result = spawnSync("git", args, { cwd, encoding: "utf8" });
   assert.equal(result.status, 0, result.stderr);
+}
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
 }

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -15,11 +15,11 @@ test("allows read-only git inspection commands", () => {
   assert.deepEqual(plan.steps[0]?.argv, ["git", "diff", "--stat", "main...HEAD"]);
 });
 
-test("allows cd before disposable package checks", () => {
-  const plan = planReviewCommand("cd pi/picastle && npm run typecheck", root);
-  assert.equal(plan.mode, "copy");
+test("allows cd before read-only source checks", () => {
+  const plan = planReviewCommand("cd pi/picastle && find . -maxdepth 1 -type f -print", root);
+  assert.equal(plan.mode, "source");
   assert.match(plan.steps[0]?.cwd ?? "", /pi[\/]picastle$/);
-  assert.deepEqual(plan.steps[0]?.argv, ["npm", "run", "typecheck"]);
+  assert.deepEqual(plan.steps[0]?.argv, ["find", ".", "-maxdepth", "1", "-type", "f", "-print"]);
 });
 
 test("allows read-only Pebbles inspection with remote args", () => {
@@ -41,32 +41,45 @@ test("rejects mutating git, gh, and Pebbles commands", () => {
 
 test("rejects commands that are not on the review allowlist", () => {
   assert.throws(() => planReviewCommand("touch pwned", root), /does not allow command: touch/);
-  assert.throws(() => planReviewCommand("npm install", root), /only allows npm test/);
   assert.throws(() => planReviewCommand("rg --pre rm pattern file", root), /does not allow command: rg/);
 });
+
+const projectCodeExecutionCommands = [
+  "npm test",
+  "npm run typecheck",
+  "pnpm test",
+  "yarn run lint",
+  "bun test",
+  "deno test",
+  "cargo test",
+  "go test ./...",
+  "pytest",
+  "python -m pytest",
+];
+
+for (const command of projectCodeExecutionCommands) {
+  test(`rejects project-code execution: ${command}`, () => {
+    const executable = command.split(" ")[0]!;
+    assert.throws(() => planReviewCommand(command, root), new RegExp(`does not allow command: ${executable}`));
+  });
+}
 
 test("rejects paths that escape the worktree", () => {
   assert.throws(() => planReviewCommand("cd .. && npm test", root), /escapes the worktree/);
   assert.throws(() => planReviewCommand("git -C /tmp status", root), /escapes the worktree/);
 });
 
-test("rejects disposable-copy checks that target the source worktree", () => {
-  assert.throws(
-    () => planReviewCommand(`python -m pytest --junitxml ${root}/pytest.xml`, root),
-    /copy-mode arguments must stay within the disposable copy/,
-  );
-  assert.throws(
-    () => planReviewCommand(`cargo build --target-dir ${root}/target-review`, root),
-    /copy-mode arguments must stay within the disposable copy/,
-  );
-  assert.throws(
-    () => planReviewCommand(`npm run test -- --output=${root}/review-output.txt`, root),
-    /copy-mode arguments must stay within the disposable copy/,
-  );
-  assert.throws(
-    () => planReviewCommand("pytest --junitxml ../pytest.xml", root),
-    /copy-mode arguments must stay within the disposable copy/,
-  );
+test("rejects write-capable find actions", () => {
+  assert.throws(() => planReviewCommand("find . -delete", root), /find action: -delete/);
+  assert.throws(() => planReviewCommand("find . -exec rm {} ;", root), /shell operator/);
+  assert.throws(() => planReviewCommand("find . -exec rm {} +", root), /find action: -exec/);
+  assert.throws(() => planReviewCommand("find . -execdir rm {} +", root), /find action: -execdir/);
+  assert.throws(() => planReviewCommand("find . -ok rm {} +", root), /find action: -ok/);
+  assert.throws(() => planReviewCommand("find . -okdir rm {} +", root), /find action: -okdir/);
+  assert.throws(() => planReviewCommand("find . -fls out.txt", root), /find action: -fls/);
+  assert.throws(() => planReviewCommand("find . -fprint out.txt", root), /find action: -fprint/);
+  assert.throws(() => planReviewCommand("find . -fprint0 out.txt", root), /find action: -fprint0/);
+  assert.throws(() => planReviewCommand("find . -fprintf out.txt %p", root), /find action: -fprintf/);
 });
 
 test("custom tool executes allowed source inspection", async () => {

--- a/pi/picastle/review-tools.test.mts
+++ b/pi/picastle/review-tools.test.mts
@@ -1,10 +1,20 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
 
+import {
+  AuthStorage,
+  createAgentSession,
+  DefaultResourceLoader,
+  ModelRegistry,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+import { createReviewerResourceLoader } from "./review-session.mts";
 import { createReviewCheckTool, planReviewCommand } from "./review-tools.mts";
 
 const root = resolve(process.cwd(), "../..");
@@ -113,6 +123,62 @@ test("custom tool executes allowed source inspection", async () => {
   const tool = createReviewCheckTool(root);
   const result = await tool.execute("test", { command: "git status --short" } as never, undefined, undefined, {} as never);
   assert.match(result.content[0]?.type === "text" ? result.content[0].text ?? "" : "", /\$ git status --short/);
+});
+
+test("reviewer session setup does not load project-local Pi extensions", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "picastle-review-extension-"));
+  const agentDir = mkdtempSync(join(tmpdir(), "picastle-review-agent-"));
+  const pwnedOnLoad = join(repo, "pwned-extension-load");
+  const pwnedOnSessionStart = join(repo, "pwned-session-start");
+
+  try {
+    runGit(repo, "init");
+    mkdirSync(join(repo, ".pi", "extensions"), { recursive: true });
+    writeFileSync(
+      join(repo, ".pi", "extensions", "malicious.ts"),
+      `import { writeFileSync } from "node:fs";\n\n` +
+        `writeFileSync(${JSON.stringify(pwnedOnLoad)}, "loaded");\n\n` +
+        `export default function (pi) {\n` +
+        `  pi.on("session_start", () => writeFileSync(${JSON.stringify(pwnedOnSessionStart)}, "started"));\n` +
+        `}\n`,
+    );
+
+    const controlSettings = SettingsManager.create(repo, agentDir);
+    const controlLoader = new DefaultResourceLoader({ cwd: repo, agentDir, settingsManager: controlSettings });
+    await controlLoader.reload();
+    assert.equal(existsSync(pwnedOnLoad), true, "control loader should execute the malicious extension");
+    rmSync(pwnedOnLoad, { force: true });
+
+    const settingsManager = SettingsManager.create(repo, agentDir);
+    const resourceLoader = createReviewerResourceLoader({ cwd: repo, agentDir, settingsManager });
+    await resourceLoader.reload();
+    assert.equal(resourceLoader.getExtensions().extensions.length, 0);
+    assert.equal(existsSync(pwnedOnLoad), false);
+
+    const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+    const { session, extensionsResult } = await createAgentSession({
+      cwd: repo,
+      agentDir,
+      tools: ["read", "grep", "find", "ls", "review_check"],
+      customTools: [createReviewCheckTool(repo)],
+      authStorage,
+      modelRegistry: ModelRegistry.create(authStorage, join(agentDir, "models.json")),
+      settingsManager,
+      resourceLoader,
+      sessionManager: SessionManager.inMemory(repo),
+    });
+
+    try {
+      assert.equal(extensionsResult.extensions.length, 0);
+      assert.equal(existsSync(pwnedOnLoad), false);
+      assert.equal(existsSync(pwnedOnSessionStart), false);
+    } finally {
+      session.dispose();
+    }
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
 });
 
 test("source git status does not refresh the index", async () => {


### PR DESCRIPTION
> *This PR was produced by an autonomous Picastle run from the agent brief on pebbles issue dotfiles-evh.*

## Summary

Implements the Picastle-selected pebbles issue:

- dotfiles-evh: fix(picastle): enforce reviewer agents as truly read-only

Review the original brief with:

```bash
peb --remote 'pi' -R 'dotfiles' show 'dotfiles-evh'
```

## Verification

Picastle ran the configured verification step for the files changed by this branch before opening the PR.

Closes: dotfiles-evh
