### PR TITLE
feat(picastle): add first-class stacked PR support

### DIFF
--- a/pi/picastle/README.md
+++ b/pi/picastle/README.md
@@ -96,6 +96,7 @@ repair/implementer path instead of running branch-controlled code.
 - `PICASTLE_PEB_REPO=ricekit`
 - `PICASTLE_PUSH=1`
 - `PICASTLE_OPEN_PRS=1`
+- `PICASTLE_STACK_PRS=1` publishes multi-issue batches as an ordered stack, with PR N targeting PR N-1
 - `PICASTLE_PUBLISHER_AGENT=1` uses the review/repair/publish pipeline for Sandcastle parity
 - `PICASTLE_REVIEW_REPAIR_CYCLES=10` max reviewer ↔ implementer repair loops
 - `PICASTLE_REVIEW_CONCURRENCY=$PICASTLE_CONCURRENCY` parallel review/publish workers
@@ -141,6 +142,8 @@ it asks the planner for new work. Recovery is handled first:
 - clean open-PR branches with no unpushed commits have their Pebbles
   closure/review state reconciled only after the Pebble lookup succeeds and the
   Pebble is still in the ready queue
+- open PRs with Picastle stack markers are retargeted to the nearest previous
+  still-open stack entry (or the base branch after upstream stack entries merge)
 - dirty open-PR branches with confirmed ready-queue Pebbles are resumed through
   implementation; clean open-PR branches with unpushed commits are
   reviewed/published so the existing PR is updated

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -585,7 +585,7 @@ function applyStackRetargetAction(action: StackRetargetAction, options: { rebase
   const baseEdit = action.updateBase ? ` --base ${shellQuote(action.expectedBase)}` : "";
   run(`gh pr edit ${shellQuote(action.prRef)}${baseEdit} --body-file ${shellQuote(bodyFile)}`, repoRoot);
   const comment = stackPebblesComment(action.stack, action.prRef);
-  if (comment) writePendingComment(result.worktreePath, action.stack.issueId, comment);
+  if (comment) postPebblesComment(result.worktreePath, action.stack.issueId, comment);
   return result.rebased;
 }
 
@@ -1594,7 +1594,17 @@ function retargetStackPrIfNeeded(issue: CompletedIssue, prRef: string): void {
 
 function recordPublishedStackPosition(issue: CompletedIssue, prRef: string): void {
   const comment = stackPebblesComment(issue.stack, prRef);
-  if (comment) writePendingComment(issue.worktreePath, issue.id, comment);
+  if (comment) postPebblesComment(issue.worktreePath, issue.id, comment);
+}
+
+function postPebblesComment(worktreePath: string, issueId: string, body: string): void {
+  const result = run(pebCommand(`comment add ${shellQuote(issueId)} ${shellQuote(body)}`), repoRoot, {
+    allowFailure: true,
+  });
+  if (result.status === 0) return;
+
+  console.warn(`  ⚠ failed to post Pebbles comment for ${issueId}: ${result.stderr || result.stdout}`);
+  writePendingComment(worktreePath, issueId, body);
 }
 
 function buildPrBody(issue: CompletedIssue): string {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -51,7 +51,18 @@ import {
   type PlannerDecision,
 } from "./planner-output.mjs";
 import { createReviewerAgentTooling, createReviewerResourceLoader } from "./review-session.mts";
-type CompletedIssue = PlannedIssue & { worktreePath: string };
+import {
+  planStackRetargets,
+  stackBaseBranch,
+  stackContext,
+  stackIssues,
+  stackPebblesComment,
+  stackPrBodySection,
+  type StackMetadata,
+  type StackPrRecord,
+} from "./stack.mjs";
+type PlannedWorkIssue = PlannedIssue & { stack?: StackMetadata };
+type CompletedIssue = PlannedWorkIssue & { worktreePath: string };
 type ReviewStatus = "approved" | "changes_requested" | "blocked";
 type ReviewFinding = {
   severity?: string;
@@ -109,6 +120,7 @@ const PLAN_ONLY = envBool("PICASTLE_PLAN_ONLY", cli.planOnly);
 const REPAIR_ON_VERIFY_FAIL = envBool("PICASTLE_REPAIR_ON_VERIFY_FAIL", true);
 const PUSH = envBool("PICASTLE_PUSH", !cli.noPush);
 const OPEN_PRS = envBool("PICASTLE_OPEN_PRS", !cli.noPr);
+const STACK_PRS = envBool("PICASTLE_STACK_PRS", false);
 const PUBLISHER_AGENT = envBool("PICASTLE_PUBLISHER_AGENT", true);
 const REVIEW_REPAIR_CYCLES = envInt("PICASTLE_REVIEW_REPAIR_CYCLES", 10);
 const REVIEW_CONCURRENCY = envInt("PICASTLE_REVIEW_CONCURRENCY", CONCURRENCY);
@@ -121,6 +133,7 @@ if (TEST_AGENT_OUTPUT !== undefined && !process.env.NODE_TEST_CONTEXT) {
 // Sandcastle PR heads before recovery/planning. This is not an unbounded "all PRs" query.
 const OPEN_PR_SCAN_LIMIT = envInt("PICASTLE_OPEN_PR_SCAN_LIMIT", 1000);
 const OPEN_PR_JSON_FIELDS = "number,headRefName,url,isCrossRepository,headRepository,headRepositoryOwner";
+const STACK_OPEN_PR_JSON_FIELDS = "number,headRefName,baseRefName,url,body,isCrossRepository,headRepository,headRepositoryOwner";
 const WORKTREE_READY_COMMAND = env("PICASTLE_WORKTREE_READY_COMMAND", "");
 const BEFORE_PUSH_COMMAND = env("PICASTLE_BEFORE_PUSH_COMMAND", "");
 const THINKING = process.env.PICASTLE_THINKING as
@@ -144,6 +157,7 @@ console.log(`Picastle runtime: ${runtimeDir}`);
 console.log(`Pebbles queue: status=${ISSUE_STATUS}${ISSUE_LABEL ? ` label=${ISSUE_LABEL}` : ""}`);
 if (MIN_FREE_GB > 0) console.log(`Disk guardrail: require ${MIN_FREE_GB} GiB free`);
 if (CLEAN_TARGETS) console.log("Disk cleanup: per-worktree target/ cleanup enabled");
+if (STACK_PRS) console.log("Stacked PR mode: enabled for multi-issue batches");
 checkMinFreeSpace("startup");
 
 for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
@@ -197,9 +211,10 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     break;
   }
 
-  const settled = await runWithConcurrency(issues, CONCURRENCY, (issue) =>
-    implementIssue(issue, iteration),
-  );
+  const plannedWork = preparePlannedIssuesForImplementation(issues);
+  const settled = STACK_PRS && plannedWork.length > 1
+    ? await runSequentially(plannedWork, (issue) => implementIssue(issue, iteration))
+    : await runWithConcurrency(plannedWork, CONCURRENCY, (issue) => implementIssue(issue, iteration));
 
   const completed: CompletedIssue[] = [];
   for (const [i, outcome] of settled.entries()) {
@@ -260,6 +275,7 @@ function recoverInterruptedRun(options: { readOnly?: boolean } = {}): RecoveryPl
     requiredLabel: ISSUE_LABEL || undefined,
   });
   logRecoveryPlan(plan);
+  reconcileOpenStackPrs(options);
 
   if (options.readOnly) {
     return { ...plan, unpublishedBranches: [] };
@@ -438,6 +454,29 @@ function loadExistingOpenPrForIssue(issueId: string): { headRefName: string; url
     repoRoot,
   );
   return findOpenPrForIssue(result.stdout, issueId, { currentRepository: loadRepositoryIdentity(), knownIssueIds });
+}
+
+function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}): void {
+  if (!OPEN_PRS) return;
+  const knownIssueIds = loadKnownIssueIdsForRecovery();
+  const result = run(
+    `gh pr list --state open --limit ${OPEN_PR_SCAN_LIMIT} --json ${STACK_OPEN_PR_JSON_FIELDS}`,
+    repoRoot,
+  );
+  const openPrs = parseJsonArray(
+    normalizeOpenPrsJson(result.stdout, { currentRepository: loadRepositoryIdentity(), knownIssueIds }),
+    "open GitHub stack PR list",
+  ) as StackPrRecord[];
+  const retargets = planStackRetargets(openPrs, BASE_BRANCH);
+  for (const action of retargets) {
+    const message = `  stack retarget: ${action.headRefName} base ${action.currentBase} → ${action.expectedBase}`;
+    if (options.readOnly) {
+      console.log(`${message} (plan-only)`);
+    } else {
+      console.log(message);
+      run(`gh pr edit ${shellQuote(action.prRef)} --base ${shellQuote(action.expectedBase)}`, repoRoot);
+    }
+  }
 }
 
 function loadKnownIssueIdsForRecovery(): string[] {
@@ -643,7 +682,7 @@ function parseJsonArray(input: string, description: string): unknown[] {
 }
 
 async function implementIssue(
-  issue: PlannedIssue,
+  issue: PlannedWorkIssue,
   iteration: number,
 ): Promise<CompletedIssue | undefined> {
   assertMutableMode("run implementer");
@@ -659,7 +698,8 @@ async function implementIssue(
       TASK_ID: issue.id,
       ISSUE_TITLE: issue.title,
       BRANCH: issue.branch,
-      BASE_BRANCH,
+      BASE_BRANCH: effectiveBaseBranch(issue),
+      STACK_CONTEXT: stackContext(issue.stack),
       ISSUE_JSON: issueJson.trim(),
       RECENT_COMMITS: recentCommits.trim(),
       PEB_PREFIX: pebCommand("").trim(),
@@ -680,7 +720,7 @@ async function implementIssue(
       console.warn(`  ⚠ ${issue.id}: worktree has uncommitted changes after implementer run`);
     }
 
-    const ahead = Number(run(`git rev-list --count ${shellQuote(BASE_BRANCH)}..HEAD`, worktreePath).stdout.trim() || "0");
+    const ahead = Number(run(`git rev-list --count ${shellQuote(effectiveBaseBranch(issue))}..HEAD`, worktreePath).stdout.trim() || "0");
     if (ahead <= 0) {
       console.log(`  - ${issue.id}: no commits produced`);
       return undefined;
@@ -703,16 +743,19 @@ async function publishCompletedIssuesWithAgent(
     `\n==> Review/repair loop handling ${completed.length} completed branch(es) with concurrency ${REVIEW_CONCURRENCY}`,
   );
 
-  const settled = await runWithConcurrency(completed, REVIEW_CONCURRENCY, async (issue) => {
-    try {
-      const approved = await reviewIssueUntilApproved(issue, iteration);
-      if (!approved) return { issue, published: false };
-      await publishApprovedIssue(issue);
-      return { issue, published: true };
-    } finally {
-      cleanWorktreeTarget(issue.worktreePath, issue.id);
-    }
-  });
+  const publishTargets = prepareCompletedIssuesForPublishing(completed);
+  const settled = STACK_PRS && publishTargets.length > 1
+    ? await reviewAndPublishStackWithAgent(publishTargets, iteration)
+    : await runWithConcurrency(publishTargets, REVIEW_CONCURRENCY, async (issue) => {
+      try {
+        const approved = await reviewIssueUntilApproved(issue, iteration);
+        if (!approved) return { issue, published: false };
+        await publishApprovedIssue(issue);
+        return { issue, published: true };
+      } finally {
+        cleanWorktreeTarget(issue.worktreePath, issue.id);
+      }
+    });
 
   for (const outcome of settled) {
     if (outcome.status === "rejected") {
@@ -720,6 +763,35 @@ async function publishCompletedIssuesWithAgent(
     } else if (!outcome.value.published) {
       console.warn(`  - ${outcome.value.issue.id}: not published`);
     }
+  }
+}
+
+async function reviewAndPublishStackWithAgent(
+  stack: CompletedIssue[],
+  iteration: number,
+): Promise<PromiseSettledResult<{ issue: CompletedIssue; published: boolean }>[]> {
+  const results: PromiseSettledResult<{ issue: CompletedIssue; published: boolean }>[] = [];
+  const approved: CompletedIssue[] = [];
+  try {
+    for (const issue of stack) {
+      const isApproved = await reviewIssueUntilApproved(issue, iteration);
+      if (!isApproved) {
+        results.push({ status: "fulfilled", value: { issue, published: false } });
+        break;
+      }
+      approved.push(issue);
+      results.push({ status: "fulfilled", value: { issue, published: false } });
+    }
+
+    if (approved.length !== stack.length) return results;
+    verifyStackMergeability(stack);
+    for (const issue of stack) await publishApprovedIssue(issue);
+    return stack.map((issue) => ({ status: "fulfilled", value: { issue, published: true } }));
+  } catch (reason) {
+    results.push({ status: "rejected", reason });
+    return results;
+  } finally {
+    for (const issue of stack) cleanWorktreeTarget(issue.worktreePath, issue.id);
   }
 }
 
@@ -772,7 +844,7 @@ async function reviewCompletedIssue(
     TASK_ID: issue.id,
     ISSUE_TITLE: issue.title,
     BRANCH: issue.branch,
-    BASE_BRANCH,
+    BASE_BRANCH: effectiveBaseBranch(issue),
     WORKTREE_PATH: issue.worktreePath,
     ISSUE_JSON: issueJson.trim(),
     PEB_PREFIX: pebCommand("").trim(),
@@ -820,7 +892,7 @@ async function repairFromReview(
     TASK_ID: issue.id,
     ISSUE_TITLE: issue.title,
     BRANCH: issue.branch,
-    BASE_BRANCH,
+    BASE_BRANCH: effectiveBaseBranch(issue),
     ISSUE_JSON: issueJson.trim(),
     REVIEW_JSON: JSON.stringify(review, null, 2),
   });
@@ -843,6 +915,7 @@ async function publishApprovedIssue(issue: CompletedIssue): Promise<void> {
   const commandDecision = decidePublishCommandBoundary(publishDecision, { push: PUSH });
   if (publishDecision.kind === "use-existing-issue-pr") {
     console.log(`  issue already has open PR on ${publishDecision.existingPr.headRefName}: ${publishDecision.existingPr.url}`);
+    recordPublishedStackPosition(issue, publishDecision.existingPr.url);
     if (declarePendingPebbleClosure(issue.id, publishDecision.existingPr.url)) {
       markIssueInReview(issue.id);
     }
@@ -863,7 +936,9 @@ async function publishApprovedIssue(issue: CompletedIssue): Promise<void> {
   }
 
   if (publishDecision.kind === "update-existing-branch-pr") {
+    retargetStackPrIfNeeded(issue, publishDecision.existingPr.url);
     console.log(`  updated existing PR on ${publishDecision.existingPr.headRefName}: ${publishDecision.existingPr.url}`);
+    recordPublishedStackPosition(issue, publishDecision.existingPr.url);
     if (declarePendingPebbleClosure(issue.id, publishDecision.existingPr.url)) {
       markIssueInReview(issue.id);
     }
@@ -875,12 +950,9 @@ async function publishApprovedIssue(issue: CompletedIssue): Promise<void> {
     return;
   }
 
-  const prBody = buildPrBody(issue);
-  const bodyFile = join(logsDir, `pr-body-${issue.id}.md`);
-  mkdirSync(dirname(bodyFile), { recursive: true });
-  writeFileSync(bodyFile, prBody);
+  const bodyFile = writePrBodyFile(issue);
   const prCreate = run(
-    `gh pr create --base ${shellQuote(BASE_BRANCH)} --head ${shellQuote(issue.branch)} --title ${shellQuote(prTitle(issue))} --body-file ${shellQuote(bodyFile)}`,
+    `gh pr create --base ${shellQuote(effectiveBaseBranch(issue))} --head ${shellQuote(issue.branch)} --title ${shellQuote(prTitle(issue))} --body-file ${shellQuote(bodyFile)}`,
     issue.worktreePath,
   );
   process.stdout.write(prCreate.stdout);
@@ -891,6 +963,7 @@ async function publishApprovedIssue(issue: CompletedIssue): Promise<void> {
     return;
   }
 
+  recordPublishedStackPosition(issue, prRef);
   if (declarePendingPebbleClosure(issue.id, prRef)) {
     markIssueInReview(issue.id);
   }
@@ -928,7 +1001,9 @@ async function publishCompletedIssues(
   iteration: number,
 ): Promise<void> {
   assertMutableMode("publish completed issues");
-  for (const issue of completed) {
+  const publishTargets = prepareCompletedIssuesForPublishing(completed);
+  if (STACK_PRS && publishTargets.length > 1) verifyStackMergeability(publishTargets);
+  for (const issue of publishTargets) {
     try {
       console.log(`\n==> Publishing ${issue.id} (${issue.branch})`);
 
@@ -936,6 +1011,7 @@ async function publishCompletedIssues(
       const publishDecision = decidePublishFlow(issue.branch, existingPr, { openPrs: OPEN_PRS });
       if (publishDecision.kind === "use-existing-issue-pr") {
         console.log(`  issue already has open PR on ${publishDecision.existingPr.headRefName}: ${publishDecision.existingPr.url}`);
+        recordPublishedStackPosition(issue, publishDecision.existingPr.url);
         if (declarePendingPebbleClosure(issue.id, publishDecision.existingPr.url)) {
           markIssueInReview(issue.id);
         }
@@ -943,11 +1019,11 @@ async function publishCompletedIssues(
       }
 
       if (VERIFY) {
-      let verified = verifyWorktree(issue.worktreePath);
+      let verified = verifyWorktree(issue.worktreePath, effectiveBaseBranch(issue));
       if (!verified.ok && REPAIR_ON_VERIFY_FAIL) {
         console.warn("  verification failed; asking Pi to repair once");
         await repairVerificationFailure(issue, verified.output, iteration);
-        verified = verifyWorktree(issue.worktreePath);
+        verified = verifyWorktree(issue.worktreePath, effectiveBaseBranch(issue));
       }
       if (!verified.ok) {
         console.error(`  ✗ verification still failing; leaving branch unpushed: ${issue.branch}`);
@@ -973,23 +1049,23 @@ async function publishCompletedIssues(
     }
 
     if (publishDecision.kind === "update-existing-branch-pr") {
+      retargetStackPrIfNeeded(issue, publishDecision.existingPr.url);
       console.log(`  updated existing PR on ${publishDecision.existingPr.headRefName}: ${publishDecision.existingPr.url}`);
+      recordPublishedStackPosition(issue, publishDecision.existingPr.url);
       if (declarePendingPebbleClosure(issue.id, publishDecision.existingPr.url)) {
         markIssueInReview(issue.id);
       }
     } else if (publishDecision.kind === "create-new-pr") {
-      const prBody = buildPrBody(issue);
-      const bodyFile = join(logsDir, `pr-body-${issue.id}.md`);
-      mkdirSync(dirname(bodyFile), { recursive: true });
-      writeFileSync(bodyFile, prBody);
+      const bodyFile = writePrBodyFile(issue);
       const prCreate = run(
-        `gh pr create --base ${shellQuote(BASE_BRANCH)} --head ${shellQuote(issue.branch)} --title ${shellQuote(prTitle(issue))} --body-file ${shellQuote(bodyFile)}`,
+        `gh pr create --base ${shellQuote(effectiveBaseBranch(issue))} --head ${shellQuote(issue.branch)} --title ${shellQuote(prTitle(issue))} --body-file ${shellQuote(bodyFile)}`,
         issue.worktreePath,
       );
       process.stdout.write(prCreate.stdout);
       process.stderr.write(prCreate.stderr);
       const prRef = extractPrRef(prCreate.stdout) || extractPrRef(prCreate.stderr);
       if (prRef) {
+        recordPublishedStackPosition(issue, prRef);
         if (declarePendingPebbleClosure(issue.id, prRef)) {
           markIssueInReview(issue.id);
         }
@@ -1020,9 +1096,9 @@ function markIssueInReview(issueId: string): void {
   }
 }
 
-function verifyWorktree(worktreePath: string): { ok: boolean; output: string } {
+function verifyWorktree(worktreePath: string, baseBranch = BASE_BRANCH): { ok: boolean; output: string } {
   checkMinFreeSpace("before verification");
-  const changed = run(`git diff --name-only ${shellQuote(BASE_BRANCH)}...HEAD`, worktreePath).stdout
+  const changed = run(`git diff --name-only ${shellQuote(baseBranch)}...HEAD`, worktreePath).stdout
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean);
@@ -1158,12 +1234,12 @@ async function runPiAgent(args: {
   }
 }
 
-function ensureIssueWorktree(issue: PlannedIssue): string {
+function ensureIssueWorktree(issue: PlannedWorkIssue): string {
   const branch = normalizeBranch(issue.branch, issue.id);
-  return ensureBranchWorktree(branch);
+  return ensureBranchWorktree(branch, effectiveBaseBranch(issue));
 }
 
-function ensureBranchWorktree(branch: string): string {
+function ensureBranchWorktree(branch: string, startPoint = BASE_BRANCH): string {
   assertMutableMode("create or attach worktree");
   assertSafeRecoveryBranchName(branch);
   const existing = collectWorktreeEntries().find((entry) => entry.branch === branch && existsSync(entry.path));
@@ -1181,7 +1257,7 @@ function ensureBranchWorktree(branch: string): string {
     });
   } else {
     run(
-      `git worktree add -b ${shellQuote(branch)} ${shellQuote(worktreePath)} ${shellQuote(BASE_BRANCH)}`,
+      `git worktree add -b ${shellQuote(branch)} ${shellQuote(worktreePath)} ${shellQuote(startPoint)}`,
       repoRoot,
       { stdio: "inherit" },
     );
@@ -1275,10 +1351,32 @@ function prTitle(issue: PlannedIssue): string {
   return issue.title.length <= 70 ? issue.title : `${issue.title.slice(0, 67)}...`;
 }
 
+function writePrBodyFile(issue: CompletedIssue): string {
+  const bodyFile = join(logsDir, `pr-body-${issue.id}.md`);
+  mkdirSync(dirname(bodyFile), { recursive: true });
+  writeFileSync(bodyFile, buildPrBody(issue));
+  return bodyFile;
+}
+
+function retargetStackPrIfNeeded(issue: CompletedIssue, prRef: string): void {
+  if (!issue.stack) return;
+  const bodyFile = writePrBodyFile(issue);
+  run(
+    `gh pr edit ${shellQuote(prRef)} --base ${shellQuote(effectiveBaseBranch(issue))} --body-file ${shellQuote(bodyFile)}`,
+    issue.worktreePath,
+  );
+}
+
+function recordPublishedStackPosition(issue: CompletedIssue, prRef: string): void {
+  const comment = stackPebblesComment(issue.stack, prRef);
+  if (comment) writePendingComment(issue.worktreePath, issue.id, comment);
+}
+
 function buildPrBody(issue: CompletedIssue): string {
+  const stackSection = stackPrBodySection(issue.stack);
   return `> *This PR was produced by an autonomous Picastle run from the agent brief on pebbles issue ${issue.id}.*
 
-## Summary
+${stackSection}## Summary
 
 Implements the Picastle-selected pebbles issue:
 
@@ -1339,6 +1437,59 @@ function cleanWorktreeTarget(worktreePath: string, issueId: string): void {
   }).stdout.trim() || "unknown size";
   console.log(`  cleaning ${issueId} target/ (${size})`);
   rmSync(targetDir, { recursive: true, force: true });
+}
+
+function preparePlannedIssuesForImplementation(issues: PlannedIssue[]): PlannedWorkIssue[] {
+  return STACK_PRS && issues.length > 1 ? stackIssues(issues, BASE_BRANCH) : issues;
+}
+
+function prepareCompletedIssuesForPublishing(completed: CompletedIssue[]): CompletedIssue[] {
+  if (!STACK_PRS || completed.length <= 1) return completed;
+  const stack = stackIssues(completed, BASE_BRANCH);
+  return stack.map((issue, index) => ({ ...issue, worktreePath: completed[index]!.worktreePath }));
+}
+
+function effectiveBaseBranch(issue: PlannedWorkIssue): string {
+  return issue.stack ? stackBaseBranch(issue.stack) : BASE_BRANCH;
+}
+
+function verifyStackMergeability(stack: CompletedIssue[]): void {
+  if (stack.length <= 1) return;
+  console.log(`  verifying stacked PR mergeability for ${stack.length} branch(es)`);
+  for (const issue of stack) {
+    const base = effectiveBaseBranch(issue);
+    const ancestor = run(`git merge-base --is-ancestor ${shellQuote(base)} ${shellQuote(issue.branch)}`, repoRoot, {
+      allowFailure: true,
+    });
+    if (ancestor.status !== 0) {
+      throw new Error(`stack branch ${issue.branch} is not based on ${base}; rebase or recreate the stack before publishing`);
+    }
+    const mergeTree = run(`git merge-tree --write-tree ${shellQuote(base)} ${shellQuote(issue.branch)}`, repoRoot, {
+      allowFailure: true,
+    });
+    if (mergeTree.status !== 0) {
+      throw new Error(`stack branch ${issue.branch} does not merge cleanly into ${base}: ${mergeTree.stderr || mergeTree.stdout}`);
+    }
+  }
+}
+
+async function runSequentially<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = [];
+  for (const [index, item] of items.entries()) {
+    try {
+      results.push({ status: "fulfilled", value: await fn(item) });
+    } catch (reason) {
+      results.push({ status: "rejected", reason });
+      for (let rest = index + 1; rest < items.length; rest += 1) {
+        results.push({ status: "rejected", reason: new Error("skipped after earlier stacked issue failed") });
+      }
+      break;
+    }
+  }
+  return results;
 }
 
 async function runWithConcurrency<T, R>(
@@ -1438,7 +1589,7 @@ function parseArgs(args: string[]): {
     else if (arg === "--min-free-gb") parsed.minFreeGb = Number(next());
     else if (arg === "--base") parsed.base = next();
     else if (arg === "--help" || arg === "-h") {
-      console.log(`Usage: picastle [--repo PATH] [--plan-only] [--max-iterations N] [--max-issues N] [--concurrency N] [--min-free-gb N] [--base BRANCH] [--clean-targets] [--no-verify] [--no-push] [--no-pr]\n\nEnvironment: PICASTLE_PEB_REMOTE, PICASTLE_PEB_REPO, PICASTLE_ISSUE_STATUS, PICASTLE_ISSUE_LABEL, PICASTLE_MAX_ISSUES, PICASTLE_PENDING_STATUS, PICASTLE_REVIEW_STATUS, PICASTLE_PLAN_ONLY, PICASTLE_VERIFY, PICASTLE_PUSH, PICASTLE_OPEN_PRS, PICASTLE_OPEN_PR_SCAN_LIMIT, PICASTLE_PUBLISHER_AGENT, PICASTLE_REVIEW_REPAIR_CYCLES, PICASTLE_REVIEW_CONCURRENCY, PICASTLE_WORKTREE_READY_COMMAND, PICASTLE_BEFORE_PUSH_COMMAND, PICASTLE_CLEAN_TARGETS, PICASTLE_MIN_FREE_GB, PICASTLE_THINKING`);
+      console.log(`Usage: picastle [--repo PATH] [--plan-only] [--max-iterations N] [--max-issues N] [--concurrency N] [--min-free-gb N] [--base BRANCH] [--clean-targets] [--no-verify] [--no-push] [--no-pr]\n\nEnvironment: PICASTLE_PEB_REMOTE, PICASTLE_PEB_REPO, PICASTLE_ISSUE_STATUS, PICASTLE_ISSUE_LABEL, PICASTLE_MAX_ISSUES, PICASTLE_PENDING_STATUS, PICASTLE_REVIEW_STATUS, PICASTLE_PLAN_ONLY, PICASTLE_VERIFY, PICASTLE_PUSH, PICASTLE_OPEN_PRS, PICASTLE_STACK_PRS, PICASTLE_OPEN_PR_SCAN_LIMIT, PICASTLE_PUBLISHER_AGENT, PICASTLE_REVIEW_REPAIR_CYCLES, PICASTLE_REVIEW_CONCURRENCY, PICASTLE_WORKTREE_READY_COMMAND, PICASTLE_BEFORE_PUSH_COMMAND, PICASTLE_CLEAN_TARGETS, PICASTLE_MIN_FREE_GB, PICASTLE_THINKING`);
       process.exit(0);
     } else {
       die(`unknown argument: ${arg}`);

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -1888,8 +1888,8 @@ function rebaseBranchWorktree(
   options: { oldUpstream?: string } = {},
 ): boolean {
   assertSafeRecoveryBranchName(branch);
-  ensureLocalRebaseBase(base);
-  const ancestor = run(`git merge-base --is-ancestor ${shellQuote(base)} ${shellQuote(branch)}`, repoRoot, {
+  const rebaseBase = resolveFreshRebaseBase(base);
+  const ancestor = run(`git merge-base --is-ancestor ${shellQuote(rebaseBase)} ${shellQuote(branch)}`, repoRoot, {
     allowFailure: true,
   });
   if (ancestor.status === 0) return false;
@@ -1900,8 +1900,8 @@ function rebaseBranchWorktree(
   const oldUpstream = resolveSafeRebaseBoundary(options.oldUpstream, branch);
   console.log(`  rebasing stack branch ${branch} onto ${base}`);
   const command = oldUpstream
-    ? `git rebase --onto ${shellQuote(base)} ${shellQuote(oldUpstream)} ${shellQuote(branch)}`
-    : `git rebase ${shellQuote(base)}`;
+    ? `git rebase --onto ${shellQuote(rebaseBase)} ${shellQuote(oldUpstream)} ${shellQuote(branch)}`
+    : `git rebase ${shellQuote(rebaseBase)}`;
   const rebase = run(command, worktreePath, { allowFailure: true });
   if (rebase.status !== 0) {
     run("git rebase --abort", worktreePath, { allowFailure: true });
@@ -1923,15 +1923,38 @@ function resolveSafeRebaseBoundary(oldUpstream: string | undefined, branch: stri
   return ancestor.status === 0 ? oldUpstream : undefined;
 }
 
-function ensureLocalRebaseBase(base: string): void {
+function resolveFreshRebaseBase(base: string): string {
+  if (base === BASE_BRANCH) {
+    const remoteBase = refreshRepositoryBaseFromOrigin(base);
+    if (remoteBase) return remoteBase;
+  }
   const exists = run(`git rev-parse --verify --quiet ${shellQuote(base)}`, repoRoot, { allowFailure: true }).status === 0;
-  if (exists) return;
+  if (exists) return base;
   if (!isRecognizedRecoveryPrHead(base)) throw new Error(`cannot rebase stack branch: missing local base ${base}`);
   const remoteRef = `origin/${base}`;
   if (!isSafeRecoveryTrackingRef(remoteRef)) throw new Error(`unsafe Picastle recovery tracking ref for ${base}: ${remoteRef}`);
   const remoteExists = run(`git rev-parse --verify --quiet ${shellQuote(remoteRef)}`, repoRoot, { allowFailure: true }).status === 0;
   if (!remoteExists) throw new Error(`cannot rebase stack branch: missing local base ${base} and ${remoteRef}`);
   run(`git branch --track ${shellQuote(base)} ${shellQuote(remoteRef)}`, repoRoot);
+  return base;
+}
+
+function refreshRepositoryBaseFromOrigin(base: string): string | undefined {
+  const hasOrigin = run("git remote get-url origin", repoRoot, { allowFailure: true }).status === 0;
+  if (!hasOrigin) return undefined;
+  const validBranch = run(`git check-ref-format --branch ${shellQuote(base)}`, repoRoot, { allowFailure: true }).status === 0;
+  if (!validBranch) throw new Error(`cannot refresh invalid repository base branch ${base}`);
+  const remoteRef = `refs/remotes/origin/${base}`;
+  const fetch = run(`git fetch --quiet origin ${shellQuote(`${base}:${remoteRef}`)}`, repoRoot, { allowFailure: true });
+  if (fetch.status !== 0) throw new Error(`failed to refresh repository base ${base} from origin: ${fetch.stderr || fetch.stdout}`);
+  const remoteExists = run(`git rev-parse --verify --quiet ${shellQuote(`${remoteRef}^{commit}`)}`, repoRoot, { allowFailure: true }).status === 0;
+  if (!remoteExists) return undefined;
+  const localExists = run(`git rev-parse --verify --quiet ${shellQuote(`${base}^{commit}`)}`, repoRoot, { allowFailure: true }).status === 0;
+  if (!localExists) return remoteRef;
+  const localIsStale = run(`git merge-base --is-ancestor ${shellQuote(base)} ${shellQuote(remoteRef)}`, repoRoot, { allowFailure: true }).status === 0;
+  if (localIsStale) return remoteRef;
+  const remoteIsStale = run(`git merge-base --is-ancestor ${shellQuote(remoteRef)} ${shellQuote(base)}`, repoRoot, { allowFailure: true }).status === 0;
+  return remoteIsStale ? base : remoteRef;
 }
 
 function verifyStackMergeability(stack: CompletedIssue[]): void {
@@ -1939,13 +1962,14 @@ function verifyStackMergeability(stack: CompletedIssue[]): void {
   console.log(`  verifying stacked PR mergeability for ${stack.length} branch(es)`);
   for (const issue of stack) {
     const base = effectiveBaseBranch(issue);
-    const ancestor = run(`git merge-base --is-ancestor ${shellQuote(base)} ${shellQuote(issue.branch)}`, repoRoot, {
+    const mergeBase = resolveFreshRebaseBase(base);
+    const ancestor = run(`git merge-base --is-ancestor ${shellQuote(mergeBase)} ${shellQuote(issue.branch)}`, repoRoot, {
       allowFailure: true,
     });
     if (ancestor.status !== 0) {
       throw new Error(`stack branch ${issue.branch} is not based on ${base}; rebase or recreate the stack before publishing`);
     }
-    const mergeTree = run(`git merge-tree --write-tree ${shellQuote(base)} ${shellQuote(issue.branch)}`, repoRoot, {
+    const mergeTree = run(`git merge-tree --write-tree ${shellQuote(mergeBase)} ${shellQuote(issue.branch)}`, repoRoot, {
       allowFailure: true,
     });
     if (mergeTree.status !== 0) {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -37,6 +37,7 @@ import {
   selectRecoveryActions,
   validatePlannedIssueSelections,
   type RecoveryBranchInput,
+  type RecoveryIssue,
   type RecoveryIssueLookup,
   type RecoveryPlan,
   type RepositoryIdentity,
@@ -135,6 +136,10 @@ const TEST_AGENT_OUTPUT = process.env.PICASTLE_TEST_AGENT_OUTPUT;
 if (TEST_AGENT_OUTPUT !== undefined && !process.env.NODE_TEST_CONTEXT) {
   throw new Error("PICASTLE_TEST_AGENT_OUTPUT is only available to the node:test harness");
 }
+const TEST_AGENT_COMMAND = process.env.PICASTLE_TEST_AGENT_COMMAND;
+if (TEST_AGENT_COMMAND !== undefined && !process.env.NODE_TEST_CONTEXT) {
+  throw new Error("PICASTLE_TEST_AGENT_COMMAND is only available to the node:test harness");
+}
 // gh pr list defaults to 30; no-cap Picastle runs can exceed that. Use a high,
 // bounded scan, then locally filter to same-repository Picastle and legacy
 // Sandcastle PR heads before recovery/planning. This is not an unbounded "all PRs" query.
@@ -174,9 +179,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   const recovery = recoverInterruptedRun({ readOnly: PLAN_ONLY });
   if (!PLAN_ONLY && recovery.interruptedImplementations.length > 0) {
     console.log("Recovery has interrupted implementation work; resuming before planning new work.");
-    const settled = await runWithConcurrency(recovery.interruptedImplementations, CONCURRENCY, (issue) =>
-      implementIssue(issue, iteration),
-    );
+    const settled = await resumeInterruptedImplementations(recovery.interruptedImplementations, iteration);
     const completed = settled.flatMap((outcome) => outcome.status === "fulfilled" && outcome.value ? [outcome.value] : []);
     for (const outcome of settled) {
       if (outcome.status === "rejected") console.error(`  ✗ recovery implementer failed: ${formatError(outcome.reason)}`);
@@ -830,6 +833,45 @@ function parseJsonArray(input: string, description: string): unknown[] {
   return parsed;
 }
 
+async function resumeInterruptedImplementations(
+  issues: RecoveryIssue[],
+  iteration: number,
+): Promise<PromiseSettledResult<CompletedIssue | undefined>[]> {
+  if (!issues.some((issue) => issue.stack)) {
+    return runWithConcurrency(issues, CONCURRENCY, (issue) => implementIssue(issue, iteration));
+  }
+
+  const ordered = orderInterruptedStackRecoveryIssues(issues);
+  console.log("Recovery contains stacked implementation work; resuming sequentially in stack order.");
+  const completedByStack = new Map<string, CompletedIssue[]>();
+  return runSequentially(ordered, async (issue) => {
+    const completed = await implementIssue(issue, iteration);
+    if (completed?.stack) {
+      const stackCompleted = [...(completedByStack.get(completed.stack.stackId) ?? []), completed]
+        .sort((a, b) => a.stack!.index - b.stack!.index || a.id.localeCompare(b.id));
+      completedByStack.set(completed.stack.stackId, stackCompleted);
+      rebaseStackOntoExpectedBases(stackCompleted);
+    }
+    return completed;
+  });
+}
+
+function orderInterruptedStackRecoveryIssues(issues: RecoveryIssue[]): RecoveryIssue[] {
+  return issues
+    .map((issue, position) => ({ issue, position }))
+    .sort((a, b) => {
+      const aStack = a.issue.stack;
+      const bStack = b.issue.stack;
+      if (aStack && bStack) {
+        if (aStack.stackId !== bStack.stackId) return aStack.stackId.localeCompare(bStack.stackId) || a.position - b.position;
+        return aStack.index - bStack.index || a.issue.id.localeCompare(b.issue.id) || a.position - b.position;
+      }
+      if (aStack || bStack) return aStack ? -1 : 1;
+      return a.position - b.position;
+    })
+    .map((entry) => entry.issue);
+}
+
 async function implementIssue(
   issue: PlannedWorkIssue,
   iteration: number,
@@ -1342,6 +1384,22 @@ async function runPiAgent(args: {
     ? createReviewerResourceLoader({ cwd: args.cwd, agentDir, settingsManager })
     : undefined;
   if (resourceLoader) await resourceLoader.reload();
+
+  if (TEST_AGENT_COMMAND !== undefined) {
+    run(TEST_AGENT_COMMAND, args.cwd, {
+      stdio: "inherit",
+      env: {
+        PICASTLE_AGENT_NAME: args.name,
+        PICASTLE_AGENT_LOG_FILE: args.logFile,
+      },
+    });
+    const output = TEST_AGENT_OUTPUT ?? "";
+    if (output) {
+      append(args.logFile, output + "\n");
+      process.stdout.write(output + "\n");
+    }
+    return output;
+  }
 
   if (TEST_AGENT_OUTPUT !== undefined) {
     append(args.logFile, TEST_AGENT_OUTPUT + "\n");

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -54,13 +54,17 @@ import {
   parseStackMetadataFromBody,
   parseStackMetadataJson,
   planStackRetargets,
+  relinkStackMetadata,
   stackBaseBranch,
   stackContext,
+  stackMetadataEqual,
   stackIssues,
   stackPebblesComment,
   stackPrBodySection,
+  upsertStackPrBodySection,
   type StackMetadata,
   type StackPrRecord,
+  type StackRetargetAction,
 } from "./stack.mjs";
 type PlannedWorkIssue = PlannedIssue & { stack?: StackMetadata };
 type CompletedIssue = PlannedWorkIssue & { worktreePath: string };
@@ -284,8 +288,9 @@ function recoverInterruptedRun(options: { readOnly?: boolean } = {}): RecoveryPl
     return { ...plan, unpublishedBranches: [] };
   }
 
+  const refreshedPlan = refreshRecoveryPlanStackMetadata(plan);
   const unpublishedBranches: CompletedIssue[] = [];
-  for (const action of selectRecoveryActions(plan, options)) {
+  for (const action of selectRecoveryActions(refreshedPlan, options)) {
     if (action.kind === "declare-pending-closure") {
       if (declarePendingPebbleClosure(action.issueId, action.prUrl)) {
         markIssueInReview(action.issueId);
@@ -298,7 +303,7 @@ function recoverInterruptedRun(options: { readOnly?: boolean } = {}): RecoveryPl
     }
   }
 
-  return { ...plan, unpublishedBranches };
+  return { ...refreshedPlan, unpublishedBranches };
 }
 
 function declarePendingPebbleClosure(issueId: string, prRef: string): boolean {
@@ -446,13 +451,7 @@ function loadRepositoryIdentity(): RepositoryIdentity {
 }
 
 function loadOpenPrRecoveryRecordsByHead(): Map<string, { url: string; stack?: StackMetadata }> {
-  const result = run(
-    `gh pr list --state open --limit ${OPEN_PR_SCAN_LIMIT} --json ${STACK_OPEN_PR_JSON_FIELDS}`,
-    repoRoot,
-  );
-  const knownIssueIds = loadKnownIssueIdsForRecovery();
-  const normalized = normalizeOpenPrsJson(result.stdout, { currentRepository: loadRepositoryIdentity(), knownIssueIds });
-  const openPrs = parseJsonArray(normalized, "open GitHub recovery PR list") as StackPrRecord[];
+  const openPrs = loadOpenStackPrRecords("open GitHub recovery PR list");
   const byHead = new Map<string, { url: string; stack?: StackMetadata }>();
   for (const pr of openPrs) {
     byHead.set(pr.headRefName, {
@@ -461,6 +460,16 @@ function loadOpenPrRecoveryRecordsByHead(): Map<string, { url: string; stack?: S
     });
   }
   return byHead;
+}
+
+function loadOpenStackPrRecords(description: string): StackPrRecord[] {
+  const result = run(
+    `gh pr list --state open --limit ${OPEN_PR_SCAN_LIMIT} --json ${STACK_OPEN_PR_JSON_FIELDS}`,
+    repoRoot,
+  );
+  const knownIssueIds = loadKnownIssueIdsForRecovery();
+  const normalized = normalizeOpenPrsJson(result.stdout, { currentRepository: loadRepositoryIdentity(), knownIssueIds });
+  return parseJsonArray(normalized, description) as StackPrRecord[];
 }
 
 function loadExistingOpenPrForIssue(issueId: string): { headRefName: string; url: string } | undefined {
@@ -474,24 +483,25 @@ function loadExistingOpenPrForIssue(issueId: string): { headRefName: string; url
 
 function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}): void {
   if (!OPEN_PRS) return;
-  const knownIssueIds = loadKnownIssueIdsForRecovery();
-  const result = run(
-    `gh pr list --state open --limit ${OPEN_PR_SCAN_LIMIT} --json ${STACK_OPEN_PR_JSON_FIELDS}`,
-    repoRoot,
-  );
-  const openPrs = parseJsonArray(
-    normalizeOpenPrsJson(result.stdout, { currentRepository: loadRepositoryIdentity(), knownIssueIds }),
-    "open GitHub stack PR list",
-  ) as StackPrRecord[];
+  const openPrs = loadOpenStackPrRecords("open GitHub stack PR list");
   const retargets = planStackRetargets(openPrs, BASE_BRANCH);
   for (const action of retargets) {
-    const message = `  stack retarget: ${action.headRefName} base ${action.currentBase} → ${action.expectedBase}`;
+    const message = action.updateBase
+      ? `  stack retarget: ${action.headRefName} base ${action.currentBase} → ${action.expectedBase}`
+      : `  stack metadata refresh: ${action.headRefName} base ${action.expectedBase}`;
     if (options.readOnly) {
       console.log(`${message} (plan-only)`);
     } else {
       console.log(message);
-      rebaseOpenStackPrBranch(action.headRefName, action.expectedBase);
-      run(`gh pr edit ${shellQuote(action.prRef)} --base ${shellQuote(action.expectedBase)}`, repoRoot);
+      const worktreePath = action.updateBase
+        ? rebaseOpenStackPrBranch(action.headRefName, action.expectedBase)
+        : ensureExistingBranchWorktree(action.headRefName);
+      persistStackMetadata(action.stack);
+      const bodyFile = writeStackPrBodyRefreshFile(action);
+      const baseEdit = action.updateBase ? ` --base ${shellQuote(action.expectedBase)}` : "";
+      run(`gh pr edit ${shellQuote(action.prRef)}${baseEdit} --body-file ${shellQuote(bodyFile)}`, repoRoot);
+      const comment = stackPebblesComment(action.stack, action.prRef);
+      if (comment) writePendingComment(worktreePath, action.stack.issueId, comment);
     }
   }
 }
@@ -969,6 +979,8 @@ async function publishApprovedIssue(issue: CompletedIssue): Promise<void> {
     return;
   }
 
+  rebaseIssueStackBranchIfNeeded(issue);
+
   if (commandDecision.shouldPush) {
     runWorktreeReadyHook(issue.worktreePath);
     if (BEFORE_PUSH_COMMAND) {
@@ -1065,6 +1077,8 @@ async function publishCompletedIssues(
         }
         continue;
       }
+
+      rebaseIssueStackBranchIfNeeded(issue);
 
       if (VERIFY) {
       let verified = verifyWorktree(issue.worktreePath, effectiveBaseBranch(issue));
@@ -1406,6 +1420,13 @@ function writePrBodyFile(issue: CompletedIssue): string {
   return bodyFile;
 }
 
+function writeStackPrBodyRefreshFile(action: StackRetargetAction): string {
+  const bodyFile = join(logsDir, `pr-body-stack-refresh-${hashString(action.headRefName)}.md`);
+  mkdirSync(dirname(bodyFile), { recursive: true });
+  writeFileSync(bodyFile, upsertStackPrBodySection(action.currentBody, action.stack));
+  return bodyFile;
+}
+
 function retargetStackPrIfNeeded(issue: CompletedIssue, prRef: string): void {
   if (!issue.stack) return;
   const bodyFile = writePrBodyFile(issue);
@@ -1492,11 +1513,69 @@ function preparePlannedIssuesForImplementation(issues: PlannedIssue[]): PlannedW
 }
 
 function prepareCompletedIssuesForPublishing(completed: CompletedIssue[]): CompletedIssue[] {
-  if (!STACK_PRS || completed.length <= 1) return completed;
-  const preserved = preservedCompletedStack(completed);
-  if (preserved) return preserved;
-  const stack = stackIssues(completed, BASE_BRANCH);
-  return stack.map((issue, index) => ({ ...issue, worktreePath: completed[index]!.worktreePath }));
+  const ordered = STACK_PRS && completed.length > 1
+    ? preservedCompletedStack(completed) ?? stackIssues(completed, BASE_BRANCH).map((issue, index) => ({ ...issue, worktreePath: completed[index]!.worktreePath }))
+    : completed;
+  return refreshCompletedStackMetadata(ordered);
+}
+
+function refreshCompletedStackMetadata(completed: CompletedIssue[]): CompletedIssue[] {
+  return refreshIssueStackMetadata(completed, "open GitHub stack PR list for recovery publishing");
+}
+
+function refreshRecoveryPlanStackMetadata(plan: RecoveryPlan): RecoveryPlan {
+  return {
+    ...plan,
+    interruptedImplementations: refreshIssueStackMetadata(plan.interruptedImplementations, "open GitHub stack PR list for interrupted recovery"),
+    unpublishedBranches: refreshIssueStackMetadata(plan.unpublishedBranches, "open GitHub stack PR list for unpublished recovery"),
+  };
+}
+
+function refreshIssueStackMetadata<T extends { branch: string; stack?: StackMetadata }>(issues: T[], openPrDescription: string): T[] {
+  if (!issues.some((issue) => issue.stack)) return issues;
+  const openPrs = OPEN_PRS ? loadOpenStackPrRecords(openPrDescription) : [];
+  const issueByBranch = new Map(issues.filter((issue) => issue.stack).map((issue) => [issue.branch, issue]));
+  const entries: Array<{ branch: string; stack: StackMetadata; issue?: T }> = [];
+
+  for (const pr of openPrs) {
+    if (issueByBranch.has(pr.headRefName)) continue;
+    const stack = parseStackMetadataFromBody(pr.body);
+    if (stack) entries.push({ branch: pr.headRefName, stack });
+  }
+  for (const issue of issues) {
+    if (issue.stack) entries.push({ branch: issue.branch, stack: issue.stack, issue });
+  }
+
+  const byStackId = new Map<string, Array<{ branch: string; stack: StackMetadata; issue?: T }>>();
+  for (const entry of entries) {
+    const group = byStackId.get(entry.stack.stackId) ?? [];
+    group.push(entry);
+    byStackId.set(entry.stack.stackId, group);
+  }
+
+  const refreshedByBranch = new Map<string, StackMetadata>();
+  for (const group of byStackId.values()) {
+    group.sort((a, b) => a.stack.index - b.stack.index || a.branch.localeCompare(b.branch));
+    for (const [index, entry] of group.entries()) {
+      if (!entry.issue) continue;
+      const refreshed = relinkStackMetadata(entry.stack, {
+        baseBranch: BASE_BRANCH,
+        headBranch: entry.branch,
+        previousBranch: group[index - 1]?.branch,
+        nextBranch: entry.stack.nextBranch,
+      });
+      refreshedByBranch.set(entry.branch, refreshed);
+      if (!stackMetadataEqual(entry.stack, refreshed)) {
+        console.log(`  stack metadata refresh: ${entry.branch} base ${stackBaseBranch(refreshed)}`);
+        persistStackMetadata(refreshed);
+      }
+    }
+  }
+
+  return issues.map((issue) => {
+    const stack = refreshedByBranch.get(issue.branch);
+    return stack ? { ...issue, stack } : issue;
+  });
 }
 
 function preservedCompletedStack(completed: CompletedIssue[]): CompletedIssue[] | undefined {
@@ -1527,19 +1606,25 @@ function rebaseDownstreamStackEntries(stack: CompletedIssue[], upstream: Complet
 
 function rebaseStackOntoExpectedBases(stack: CompletedIssue[]): void {
   for (const issue of stack) {
-    rebaseBranchWorktree(issue.worktreePath, issue.branch, effectiveBaseBranch(issue));
+    rebaseIssueStackBranchIfNeeded(issue);
   }
 }
 
-function rebaseOpenStackPrBranch(branch: string, expectedBase: string): void {
+function rebaseIssueStackBranchIfNeeded(issue: CompletedIssue): void {
+  if (!issue.stack) return;
+  rebaseBranchWorktree(issue.worktreePath, issue.branch, effectiveBaseBranch(issue));
+}
+
+function rebaseOpenStackPrBranch(branch: string, expectedBase: string): string {
   const worktreePath = ensureExistingBranchWorktree(branch);
   const rebased = rebaseBranchWorktree(worktreePath, branch, expectedBase);
-  if (!rebased) return;
+  if (!rebased) return worktreePath;
   if (!PUSH) {
     console.log("PICASTLE_PUSH=0; skipping force-with-lease update after stack rebase");
-    return;
+    return worktreePath;
   }
   run(`git push -u origin ${shellQuote(branch)} --force-with-lease`, worktreePath, { stdio: "inherit" });
+  return worktreePath;
 }
 
 function ensureExistingBranchWorktree(branch: string): string {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -550,7 +550,17 @@ function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}, dirtyBranch
         upstreamRebased = false;
         continue;
       }
-      upstreamRebased = rebaseOpenStackPrBranch(entry.pr.headRefName, stackBaseBranch(refreshedStack), refreshedStack).rebased || upstreamRebased;
+      upstreamRebased = applyStackRetargetAction({
+        prRef: entry.pr.url || (entry.pr.number ? String(entry.pr.number) : entry.pr.headRefName),
+        headRefName: entry.pr.headRefName,
+        currentBase: entry.pr.baseRefName,
+        expectedBase: stackBaseBranch(refreshedStack),
+        stack: refreshedStack,
+        currentBody: entry.pr.body,
+        updateBase: false,
+        updateBody: true,
+        effectiveBaseChanged: false,
+      }, { rebaseBranch: true }) || upstreamRebased;
     }
   }
 

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -34,7 +34,6 @@ import {
   normalizeOpenPrsJson,
   pebClosureRegistrationSucceeded,
   parseKnownIssueIdsJson,
-  parseOpenPrsByHead,
   selectRecoveryActions,
   validatePlannedIssueSelections,
   type RecoveryBranchInput,
@@ -52,6 +51,8 @@ import {
 } from "./planner-output.mjs";
 import { createReviewerAgentTooling, createReviewerResourceLoader } from "./review-session.mts";
 import {
+  parseStackMetadataFromBody,
+  parseStackMetadataJson,
   planStackRetargets,
   stackBaseBranch,
   stackContext,
@@ -100,8 +101,10 @@ const cacheRoot = process.env.XDG_CACHE_HOME || join(requireHome(), ".cache");
 const runtimeDir = join(cacheRoot, "picastle", safeRepoId(repoRoot));
 const logsDir = join(runtimeDir, "logs");
 const worktreesDir = join(runtimeDir, "worktrees");
+const stackMetadataDir = join(runtimeDir, "stacks");
 mkdirSync(logsDir, { recursive: true });
 mkdirSync(worktreesDir, { recursive: true });
+mkdirSync(stackMetadataDir, { recursive: true });
 
 const policy = loadPebblesPolicy(repoRoot);
 const queuePolicy = deriveQueuePolicy(policy);
@@ -314,7 +317,7 @@ function declarePendingPebbleClosure(issueId: string, prRef: string): boolean {
 function collectRecoveryBranches(): RecoveryBranchInput[] {
   const worktrees = collectWorktreeEntries();
   const worktreeByBranch = new Map(worktrees.filter((entry) => entry.branch).map((entry) => [entry.branch!, entry]));
-  const openPrByHead = loadOpenPrsByHead();
+  const openPrByHead = loadOpenPrRecoveryRecordsByHead();
   const issueCache = new Map<string, { title?: string; status?: string; labels?: string[]; lookup: RecoveryIssueLookup } | undefined>();
   const knownIssueIds = loadKnownIssueIdsForRecovery();
 
@@ -322,7 +325,8 @@ function collectRecoveryBranches(): RecoveryBranchInput[] {
   const localBranchNames = new Set(localBranches.map((branch) => branch.branch));
   const inputs: RecoveryBranchInput[] = localBranches.map((localBranch) => {
     assertSafeRecoveryBranchName(localBranch.branch);
-    const openPrUrl = openPrByHead.get(localBranch.branch);
+    const openPr = openPrByHead.get(localBranch.branch);
+    const openPrUrl = openPr?.url;
     const issueId = openPrUrl
       ? extractIssueIdFromOpenPrHead(localBranch.branch, knownIssueIds)
       : extractIssueIdFromBranch(localBranch.branch, knownIssueIds);
@@ -353,10 +357,11 @@ function collectRecoveryBranches(): RecoveryBranchInput[] {
       worktreePath: worktree?.path,
       openPrUrl,
       commitTime: localBranch.commitTime,
+      stack: loadPersistedStackMetadata(localBranch.branch) ?? openPr?.stack,
     };
   });
 
-  for (const [head, url] of openPrByHead) {
+  for (const [head, openPr] of openPrByHead) {
     if (!isRecognizedRecoveryPrHead(head) || localBranchNames.has(head)) continue;
     const issueId = extractIssueIdFromOpenPrHead(head, knownIssueIds);
     const issue = issueId ? readIssueForRecovery(issueId, issueCache) : undefined;
@@ -369,7 +374,8 @@ function collectRecoveryBranches(): RecoveryBranchInput[] {
       issueLookup: issue?.lookup,
       ahead: 0,
       dirty: false,
-      openPrUrl: url,
+      openPrUrl: openPr.url,
+      stack: openPr.stack ?? loadPersistedStackMetadata(head),
     });
   }
 
@@ -439,12 +445,22 @@ function loadRepositoryIdentity(): RepositoryIdentity {
   return cachedRepositoryIdentity;
 }
 
-function loadOpenPrsByHead(): Map<string, string> {
+function loadOpenPrRecoveryRecordsByHead(): Map<string, { url: string; stack?: StackMetadata }> {
   const result = run(
-    `gh pr list --state open --limit ${OPEN_PR_SCAN_LIMIT} --json ${OPEN_PR_JSON_FIELDS}`,
+    `gh pr list --state open --limit ${OPEN_PR_SCAN_LIMIT} --json ${STACK_OPEN_PR_JSON_FIELDS}`,
     repoRoot,
   );
-  return parseOpenPrsByHead(result.stdout, { currentRepository: loadRepositoryIdentity() });
+  const knownIssueIds = loadKnownIssueIdsForRecovery();
+  const normalized = normalizeOpenPrsJson(result.stdout, { currentRepository: loadRepositoryIdentity(), knownIssueIds });
+  const openPrs = parseJsonArray(normalized, "open GitHub recovery PR list") as StackPrRecord[];
+  const byHead = new Map<string, { url: string; stack?: StackMetadata }>();
+  for (const pr of openPrs) {
+    byHead.set(pr.headRefName, {
+      url: pr.url || (pr.number ? String(pr.number) : pr.headRefName),
+      stack: parseStackMetadataFromBody(pr.body),
+    });
+  }
+  return byHead;
 }
 
 function loadExistingOpenPrForIssue(issueId: string): { headRefName: string; url: string } | undefined {
@@ -474,9 +490,38 @@ function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}): void {
       console.log(`${message} (plan-only)`);
     } else {
       console.log(message);
+      rebaseOpenStackPrBranch(action.headRefName, action.expectedBase);
       run(`gh pr edit ${shellQuote(action.prRef)} --base ${shellQuote(action.expectedBase)}`, repoRoot);
     }
   }
+}
+
+function persistStackMetadata(stack: StackMetadata): void {
+  assertSafeRecoveryBranchName(stack.headBranch);
+  mkdirSync(stackMetadataDir, { recursive: true });
+  writeFileSync(stackMetadataPath(stack.headBranch), JSON.stringify(stack, null, 2));
+}
+
+function loadPersistedStackMetadata(branch: string): StackMetadata | undefined {
+  if (!branch.startsWith("picastle/")) return undefined;
+  assertSafeRecoveryBranchName(branch);
+  const path = stackMetadataPath(branch);
+  if (!existsSync(path)) return undefined;
+  try {
+    const stack = parseStackMetadataJson(JSON.parse(readFileSync(path, "utf8")));
+    if (!stack || stack.headBranch !== branch) {
+      console.warn(`  ⚠ ignoring invalid Picastle stack metadata for ${branch}`);
+      return undefined;
+    }
+    return stack;
+  } catch (error) {
+    console.warn(`  ⚠ failed to read Picastle stack metadata for ${branch}: ${formatError(error)}`);
+    return undefined;
+  }
+}
+
+function stackMetadataPath(branch: string): string {
+  return join(stackMetadataDir, `${hashString(branch)}.json`);
 }
 
 function loadKnownIssueIdsForRecovery(): string[] {
@@ -780,10 +825,12 @@ async function reviewAndPublishStackWithAgent(
         break;
       }
       approved.push(issue);
+      rebaseDownstreamStackEntries(stack, issue);
       results.push({ status: "fulfilled", value: { issue, published: false } });
     }
 
     if (approved.length !== stack.length) return results;
+    rebaseStackOntoExpectedBases(stack);
     verifyStackMergeability(stack);
     for (const issue of stack) await publishApprovedIssue(issue);
     return stack.map((issue) => ({ status: "fulfilled", value: { issue, published: true } }));
@@ -928,9 +975,7 @@ async function publishApprovedIssue(issue: CompletedIssue): Promise<void> {
       console.log(`  before-push: ${BEFORE_PUSH_COMMAND}`);
       run(BEFORE_PUSH_COMMAND, issue.worktreePath, { stdio: "inherit" });
     }
-    run(`git push -u origin ${shellQuote(issue.branch)}`, issue.worktreePath, {
-      stdio: "inherit",
-    });
+    pushIssueBranch(issue, publishDecision.kind === "update-existing-branch-pr");
   } else {
     console.log("PICASTLE_PUSH=0; skipping git push");
   }
@@ -1002,7 +1047,10 @@ async function publishCompletedIssues(
 ): Promise<void> {
   assertMutableMode("publish completed issues");
   const publishTargets = prepareCompletedIssuesForPublishing(completed);
-  if (STACK_PRS && publishTargets.length > 1) verifyStackMergeability(publishTargets);
+  if (STACK_PRS && publishTargets.length > 1) {
+    rebaseStackOntoExpectedBases(publishTargets);
+    verifyStackMergeability(publishTargets);
+  }
   for (const issue of publishTargets) {
     try {
       console.log(`\n==> Publishing ${issue.id} (${issue.branch})`);
@@ -1041,9 +1089,7 @@ async function publishCompletedIssues(
         console.log(`  before-push: ${BEFORE_PUSH_COMMAND}`);
         run(BEFORE_PUSH_COMMAND, issue.worktreePath, { stdio: "inherit" });
       }
-      run(`git push -u origin ${shellQuote(issue.branch)}`, issue.worktreePath, {
-        stdio: "inherit",
-      });
+      pushIssueBranch(issue, publishDecision.kind === "update-existing-branch-pr");
     } else {
       console.log("PICASTLE_PUSH=0; skipping git push");
     }
@@ -1236,7 +1282,9 @@ async function runPiAgent(args: {
 
 function ensureIssueWorktree(issue: PlannedWorkIssue): string {
   const branch = normalizeBranch(issue.branch, issue.id);
-  return ensureBranchWorktree(branch, effectiveBaseBranch(issue));
+  const worktreePath = ensureBranchWorktree(branch, effectiveBaseBranch(issue));
+  if (issue.stack) persistStackMetadata({ ...issue.stack, headBranch: branch });
+  return worktreePath;
 }
 
 function ensureBranchWorktree(branch: string, startPoint = BASE_BRANCH): string {
@@ -1445,12 +1493,97 @@ function preparePlannedIssuesForImplementation(issues: PlannedIssue[]): PlannedW
 
 function prepareCompletedIssuesForPublishing(completed: CompletedIssue[]): CompletedIssue[] {
   if (!STACK_PRS || completed.length <= 1) return completed;
+  const preserved = preservedCompletedStack(completed);
+  if (preserved) return preserved;
   const stack = stackIssues(completed, BASE_BRANCH);
   return stack.map((issue, index) => ({ ...issue, worktreePath: completed[index]!.worktreePath }));
 }
 
+function preservedCompletedStack(completed: CompletedIssue[]): CompletedIssue[] | undefined {
+  if (!completed.every((issue) => issue.stack)) return undefined;
+  const stackId = completed[0]!.stack!.stackId;
+  if (!completed.every((issue) => issue.stack!.stackId === stackId && issue.stack!.total === completed.length)) return undefined;
+  return [...completed].sort((a, b) => a.stack!.index - b.stack!.index || a.id.localeCompare(b.id));
+}
+
 function effectiveBaseBranch(issue: PlannedWorkIssue): string {
   return issue.stack ? stackBaseBranch(issue.stack) : BASE_BRANCH;
+}
+
+function pushIssueBranch(issue: CompletedIssue, forceWithLease: boolean): void {
+  const forceFlag = forceWithLease ? " --force-with-lease" : "";
+  run(`git push -u origin ${shellQuote(issue.branch)}${forceFlag}`, issue.worktreePath, {
+    stdio: "inherit",
+  });
+}
+
+function rebaseDownstreamStackEntries(stack: CompletedIssue[], upstream: CompletedIssue): void {
+  const index = stack.findIndex((issue) => issue.branch === upstream.branch);
+  if (index < 0 || index >= stack.length - 1) return;
+  rebaseStackOntoExpectedBases(stack.slice(index + 1));
+}
+
+function rebaseStackOntoExpectedBases(stack: CompletedIssue[]): void {
+  for (const issue of stack) {
+    rebaseBranchWorktree(issue.worktreePath, issue.branch, effectiveBaseBranch(issue));
+  }
+}
+
+function rebaseOpenStackPrBranch(branch: string, expectedBase: string): void {
+  const worktreePath = ensureExistingBranchWorktree(branch);
+  const rebased = rebaseBranchWorktree(worktreePath, branch, expectedBase);
+  if (!rebased) return;
+  if (!PUSH) {
+    console.log("PICASTLE_PUSH=0; skipping force-with-lease update after stack rebase");
+    return;
+  }
+  run(`git push -u origin ${shellQuote(branch)} --force-with-lease`, worktreePath, { stdio: "inherit" });
+}
+
+function ensureExistingBranchWorktree(branch: string): string {
+  assertSafeRecoveryBranchName(branch);
+  const branchExists = run(`git rev-parse --verify ${shellQuote(branch)}`, repoRoot, { allowFailure: true }).status === 0;
+  if (!branchExists) {
+    const remoteRef = `origin/${branch}`;
+    if (!isSafeRecoveryTrackingRef(remoteRef)) {
+      throw new Error(`unsafe Picastle recovery tracking ref for ${branch}: ${remoteRef}`);
+    }
+    const remoteExists = run(`git rev-parse --verify --quiet ${shellQuote(remoteRef)}`, repoRoot, { allowFailure: true }).status === 0;
+    if (!remoteExists) throw new Error(`cannot rebase stack branch ${branch}: no local branch or ${remoteRef}`);
+    run(`git branch --track ${shellQuote(branch)} ${shellQuote(remoteRef)}`, repoRoot);
+  }
+  return ensureBranchWorktree(branch);
+}
+
+function rebaseBranchWorktree(worktreePath: string, branch: string, base: string): boolean {
+  assertSafeRecoveryBranchName(branch);
+  ensureLocalRebaseBase(base);
+  const ancestor = run(`git merge-base --is-ancestor ${shellQuote(base)} ${shellQuote(branch)}`, repoRoot, {
+    allowFailure: true,
+  });
+  if (ancestor.status === 0) return false;
+
+  const dirty = run("git status --porcelain", worktreePath).stdout.trim();
+  if (dirty) throw new Error(`refusing to rebase dirty stack worktree ${branch}`);
+
+  console.log(`  rebasing stack branch ${branch} onto ${base}`);
+  const rebase = run(`git rebase ${shellQuote(base)}`, worktreePath, { allowFailure: true });
+  if (rebase.status !== 0) {
+    run("git rebase --abort", worktreePath, { allowFailure: true });
+    throw new Error(`failed to rebase stack branch ${branch} onto ${base}: ${rebase.stderr || rebase.stdout}`);
+  }
+  return true;
+}
+
+function ensureLocalRebaseBase(base: string): void {
+  const exists = run(`git rev-parse --verify --quiet ${shellQuote(base)}`, repoRoot, { allowFailure: true }).status === 0;
+  if (exists) return;
+  if (!isRecognizedRecoveryPrHead(base)) throw new Error(`cannot rebase stack branch: missing local base ${base}`);
+  const remoteRef = `origin/${base}`;
+  if (!isSafeRecoveryTrackingRef(remoteRef)) throw new Error(`unsafe Picastle recovery tracking ref for ${base}: ${remoteRef}`);
+  const remoteExists = run(`git rev-parse --verify --quiet ${shellQuote(remoteRef)}`, repoRoot, { allowFailure: true }).status === 0;
+  if (!remoteExists) throw new Error(`cannot rebase stack branch: missing local base ${base} and ${remoteRef}`);
+  run(`git branch --track ${shellQuote(base)} ${shellQuote(remoteRef)}`, repoRoot);
 }
 
 function verifyStackMergeability(stack: CompletedIssue[]): void {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -339,14 +339,8 @@ function collectRecoveryBranches(): RecoveryBranchInput[] {
     const dirty = worktree?.path && existsSync(worktree.path)
       ? run("git status --porcelain", worktree.path).stdout.trim().length > 0
       : false;
-    const aheadOutput = run(
-      `git rev-list --count ${shellQuote(BASE_BRANCH)}..${shellQuote(localBranch.branch)}`,
-      repoRoot,
-    ).stdout.trim();
-    const ahead = Number(aheadOutput);
-    if (!Number.isFinite(ahead)) {
-      throw new Error(`invalid git rev-list ahead count for ${localBranch.branch}: ${aheadOutput}`);
-    }
+    const stack = loadPersistedStackMetadata(localBranch.branch) ?? openPr?.stack;
+    const ahead = countRecoverableCommits(localBranch.branch, stack);
     const unpushed = openPrUrl ? countUnpushedCommits(localBranch.branch, ahead) : 0;
     const issue = issueId ? readIssueForRecovery(issueId, issueCache) : undefined;
     return {
@@ -362,7 +356,7 @@ function collectRecoveryBranches(): RecoveryBranchInput[] {
       worktreePath: worktree?.path,
       openPrUrl,
       commitTime: localBranch.commitTime,
-      stack: loadPersistedStackMetadata(localBranch.branch) ?? openPr?.stack,
+      stack,
     };
   });
 
@@ -385,6 +379,35 @@ function collectRecoveryBranches(): RecoveryBranchInput[] {
   }
 
   return inputs;
+}
+
+function countRecoverableCommits(branch: string, stack?: StackMetadata): number {
+  assertSafeRecoveryBranchName(branch);
+  const base = stack ? stackBaseBranch(stack) : BASE_BRANCH;
+  const baseRef = resolveRecoveryComparisonBase(base) ?? (base === BASE_BRANCH ? undefined : resolveRecoveryComparisonBase(BASE_BRANCH));
+  if (!baseRef) throw new Error(`cannot compare recovery branch ${branch}: missing base ${base}`);
+  if (baseRef !== base) {
+    console.warn(`  ⚠ recovery compare base ${base} missing for ${branch}; falling back to ${baseRef}`);
+  }
+  const aheadOutput = run(
+    `git rev-list --count ${shellQuote(baseRef)}..${shellQuote(branch)}`,
+    repoRoot,
+  ).stdout.trim();
+  const ahead = Number(aheadOutput);
+  if (!Number.isFinite(ahead)) {
+    throw new Error(`invalid git rev-list ahead count for ${branch} against ${baseRef}: ${aheadOutput}`);
+  }
+  return ahead;
+}
+
+function resolveRecoveryComparisonBase(base: string): string | undefined {
+  const exists = run(`git rev-parse --verify --quiet ${shellQuote(base)}`, repoRoot, { allowFailure: true }).status === 0;
+  if (exists) return base;
+  if (!isRecognizedRecoveryPrHead(base)) return undefined;
+  const remoteRef = `origin/${base}`;
+  if (!isSafeRecoveryTrackingRef(remoteRef)) throw new Error(`unsafe Picastle recovery tracking ref for ${base}: ${remoteRef}`);
+  const remoteExists = run(`git rev-parse --verify --quiet ${shellQuote(remoteRef)}`, repoRoot, { allowFailure: true }).status === 0;
+  return remoteExists ? remoteRef : undefined;
 }
 
 function countUnpushedCommits(branch: string, fallbackWhenNoTracking: number): number {
@@ -1633,7 +1656,7 @@ function refreshIssueStackMetadata<T extends { branch: string; stack?: StackMeta
         baseBranch: BASE_BRANCH,
         headBranch: entry.branch,
         previousBranch: group[index - 1]?.branch,
-        nextBranch: entry.stack.nextBranch,
+        nextBranch: group[index + 1]?.branch,
       });
       refreshedByBranch.set(entry.branch, refreshed);
       if (!stackMetadataEqual(entry.stack, refreshed)) {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -1502,7 +1502,9 @@ function prepareCompletedIssuesForPublishing(completed: CompletedIssue[]): Compl
 function preservedCompletedStack(completed: CompletedIssue[]): CompletedIssue[] | undefined {
   if (!completed.every((issue) => issue.stack)) return undefined;
   const stackId = completed[0]!.stack!.stackId;
-  if (!completed.every((issue) => issue.stack!.stackId === stackId && issue.stack!.total === completed.length)) return undefined;
+  const total = completed[0]!.stack!.total;
+  if (total < completed.length) return undefined;
+  if (!completed.every((issue) => issue.stack!.stackId === stackId && issue.stack!.total === total)) return undefined;
   return [...completed].sort((a, b) => a.stack!.index - b.stack!.index || a.id.localeCompare(b.id));
 }
 

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -577,7 +577,7 @@ function logStackRetargetAction(action: StackRetargetAction, readOnly = false): 
 
 function applyStackRetargetAction(action: StackRetargetAction, options: { rebaseBranch?: boolean } = {}): boolean {
   logStackRetargetAction(action);
-  const result = action.updateBase || options.rebaseBranch
+  const result = action.updateBase || action.effectiveBaseChanged || options.rebaseBranch
     ? rebaseOpenStackPrBranch(action.headRefName, action.expectedBase)
     : { worktreePath: ensureExistingBranchWorktree(action.headRefName), rebased: false };
   persistStackMetadata(action.stack);
@@ -1811,6 +1811,7 @@ function rebasePublishedStackDownstreamOpenPrs(issue: CompletedIssue): void {
       currentBody: entry.pr.body,
       updateBase: Boolean(entry.pr.baseRefName && entry.pr.baseRefName !== expectedBase),
       updateBody: !stackMetadataEqual(entry.stack, refreshedStack),
+      effectiveBaseChanged: stackBaseBranch(entry.stack) !== expectedBase,
     }, { rebaseBranch: true });
   }
 }

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -485,25 +485,72 @@ function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}): void {
   if (!OPEN_PRS) return;
   const openPrs = loadOpenStackPrRecords("open GitHub stack PR list");
   const retargets = planStackRetargets(openPrs, BASE_BRANCH);
-  for (const action of retargets) {
-    const message = action.updateBase
-      ? `  stack retarget: ${action.headRefName} base ${action.currentBase} → ${action.expectedBase}`
-      : `  stack metadata refresh: ${action.headRefName} base ${action.expectedBase}`;
-    if (options.readOnly) {
-      console.log(`${message} (plan-only)`);
-    } else {
-      console.log(message);
-      const worktreePath = action.updateBase
-        ? rebaseOpenStackPrBranch(action.headRefName, action.expectedBase)
-        : ensureExistingBranchWorktree(action.headRefName);
-      persistStackMetadata(action.stack);
-      const bodyFile = writeStackPrBodyRefreshFile(action);
-      const baseEdit = action.updateBase ? ` --base ${shellQuote(action.expectedBase)}` : "";
-      run(`gh pr edit ${shellQuote(action.prRef)}${baseEdit} --body-file ${shellQuote(bodyFile)}`, repoRoot);
-      const comment = stackPebblesComment(action.stack, action.prRef);
-      if (comment) writePendingComment(worktreePath, action.stack.issueId, comment);
+  if (options.readOnly) {
+    for (const action of retargets) logStackRetargetAction(action, true);
+    return;
+  }
+
+  const actionsByHead = new Map(retargets.map((action) => [action.headRefName, action]));
+  const applied = new Set<string>();
+  for (const group of openStackPrGroups(openPrs)) {
+    let upstreamRebased = false;
+    for (const [index, entry] of group.entries()) {
+      const action = actionsByHead.get(entry.pr.headRefName);
+      if (action) {
+        upstreamRebased = applyStackRetargetAction(action, { rebaseBranch: upstreamRebased }) || upstreamRebased;
+        applied.add(action.headRefName);
+        continue;
+      }
+
+      if (!upstreamRebased) continue;
+      const refreshedStack = relinkStackMetadata(entry.stack, {
+        baseBranch: BASE_BRANCH,
+        headBranch: entry.pr.headRefName,
+        previousBranch: group[index - 1]?.pr.headRefName,
+        nextBranch: entry.stack.nextBranch,
+      });
+      upstreamRebased = rebaseOpenStackPrBranch(entry.pr.headRefName, stackBaseBranch(refreshedStack)).rebased || upstreamRebased;
     }
   }
+
+  for (const action of retargets) {
+    if (!applied.has(action.headRefName)) applyStackRetargetAction(action);
+  }
+}
+
+function logStackRetargetAction(action: StackRetargetAction, readOnly = false): void {
+  const message = action.updateBase
+    ? `  stack retarget: ${action.headRefName} base ${action.currentBase} → ${action.expectedBase}`
+    : `  stack metadata refresh: ${action.headRefName} base ${action.expectedBase}`;
+  console.log(readOnly ? `${message} (plan-only)` : message);
+}
+
+function applyStackRetargetAction(action: StackRetargetAction, options: { rebaseBranch?: boolean } = {}): boolean {
+  logStackRetargetAction(action);
+  const result = action.updateBase || options.rebaseBranch
+    ? rebaseOpenStackPrBranch(action.headRefName, action.expectedBase)
+    : { worktreePath: ensureExistingBranchWorktree(action.headRefName), rebased: false };
+  persistStackMetadata(action.stack);
+  const bodyFile = writeStackPrBodyRefreshFile(action);
+  const baseEdit = action.updateBase ? ` --base ${shellQuote(action.expectedBase)}` : "";
+  run(`gh pr edit ${shellQuote(action.prRef)}${baseEdit} --body-file ${shellQuote(bodyFile)}`, repoRoot);
+  const comment = stackPebblesComment(action.stack, action.prRef);
+  if (comment) writePendingComment(result.worktreePath, action.stack.issueId, comment);
+  return result.rebased;
+}
+
+function openStackPrGroups(openPrs: StackPrRecord[]): Array<Array<{ pr: StackPrRecord; stack: StackMetadata }>> {
+  const byStackId = new Map<string, Array<{ pr: StackPrRecord; stack: StackMetadata }>>();
+  for (const pr of openPrs) {
+    const stack = parseStackMetadataFromBody(pr.body);
+    if (!stack) continue;
+    const group = byStackId.get(stack.stackId) ?? [];
+    group.push({ pr, stack });
+    byStackId.set(stack.stackId, group);
+  }
+  return [...byStackId.values()].map((group) =>
+    group.sort((a, b) => a.stack.index - b.stack.index || a.pr.headRefName.localeCompare(b.pr.headRefName)),
+  );
 }
 
 function persistStackMetadata(stack: StackMetadata): void {
@@ -1615,16 +1662,16 @@ function rebaseIssueStackBranchIfNeeded(issue: CompletedIssue): void {
   rebaseBranchWorktree(issue.worktreePath, issue.branch, effectiveBaseBranch(issue));
 }
 
-function rebaseOpenStackPrBranch(branch: string, expectedBase: string): string {
+function rebaseOpenStackPrBranch(branch: string, expectedBase: string): { worktreePath: string; rebased: boolean } {
   const worktreePath = ensureExistingBranchWorktree(branch);
   const rebased = rebaseBranchWorktree(worktreePath, branch, expectedBase);
-  if (!rebased) return worktreePath;
+  if (!rebased) return { worktreePath, rebased: false };
   if (!PUSH) {
     console.log("PICASTLE_PUSH=0; skipping force-with-lease update after stack rebase");
-    return worktreePath;
+    return { worktreePath, rebased: true };
   }
   run(`git push -u origin ${shellQuote(branch)} --force-with-lease`, worktreePath, { stdio: "inherit" });
-  return worktreePath;
+  return { worktreePath, rebased: true };
 }
 
 function ensureExistingBranchWorktree(branch: string): string {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -282,7 +282,7 @@ function recoverInterruptedRun(options: { readOnly?: boolean } = {}): RecoveryPl
     requiredLabel: ISSUE_LABEL || undefined,
   });
   logRecoveryPlan(plan);
-  reconcileOpenStackPrs(options);
+  reconcileOpenStackPrs(options, dirtyStackBranches(branchInputs));
 
   if (options.readOnly) {
     return { ...plan, unpublishedBranches: [] };
@@ -481,7 +481,11 @@ function loadExistingOpenPrForIssue(issueId: string): { headRefName: string; url
   return findOpenPrForIssue(result.stdout, issueId, { currentRepository: loadRepositoryIdentity(), knownIssueIds });
 }
 
-function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}): void {
+function dirtyStackBranches(branches: RecoveryBranchInput[]): Set<string> {
+  return new Set(branches.filter((branch) => branch.dirty && branch.stack).map((branch) => branch.branch));
+}
+
+function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}, dirtyBranches = new Set<string>()): void {
   if (!OPEN_PRS) return;
   const openPrs = loadOpenStackPrRecords("open GitHub stack PR list");
   const retargets = planStackRetargets(openPrs, BASE_BRANCH);
@@ -497,6 +501,12 @@ function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}): void {
     for (const [index, entry] of group.entries()) {
       const action = actionsByHead.get(entry.pr.headRefName);
       if (action) {
+        if (dirtyBranches.has(action.headRefName)) {
+          logStackReconcileDeferred(action.headRefName, action.expectedBase);
+          applied.add(action.headRefName);
+          upstreamRebased = false;
+          continue;
+        }
         upstreamRebased = applyStackRetargetAction(action, { rebaseBranch: upstreamRebased }) || upstreamRebased;
         applied.add(action.headRefName);
         continue;
@@ -509,13 +519,27 @@ function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}): void {
         previousBranch: group[index - 1]?.pr.headRefName,
         nextBranch: entry.stack.nextBranch,
       });
+      if (dirtyBranches.has(entry.pr.headRefName)) {
+        logStackReconcileDeferred(entry.pr.headRefName, stackBaseBranch(refreshedStack));
+        upstreamRebased = false;
+        continue;
+      }
       upstreamRebased = rebaseOpenStackPrBranch(entry.pr.headRefName, stackBaseBranch(refreshedStack)).rebased || upstreamRebased;
     }
   }
 
   for (const action of retargets) {
-    if (!applied.has(action.headRefName)) applyStackRetargetAction(action);
+    if (applied.has(action.headRefName)) continue;
+    if (dirtyBranches.has(action.headRefName)) {
+      logStackReconcileDeferred(action.headRefName, action.expectedBase);
+      continue;
+    }
+    applyStackRetargetAction(action);
   }
+}
+
+function logStackReconcileDeferred(headRefName: string, expectedBase: string): void {
+  console.warn(`  stack reconcile deferred: ${headRefName} base ${expectedBase} (dirty worktree; recovery will resume it first)`);
 }
 
 function logStackRetargetAction(action: StackRetargetAction, readOnly = false): void {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -543,7 +543,7 @@ function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}, dirtyBranch
         baseBranch: BASE_BRANCH,
         headBranch: entry.pr.headRefName,
         previousBranch: group[index - 1]?.pr.headRefName,
-        nextBranch: entry.stack.nextBranch,
+        nextBranch: group[index + 1]?.pr.headRefName,
       });
       if (dirtyBranches.has(entry.pr.headRefName)) {
         logStackReconcileDeferred(entry.pr.headRefName, stackBaseBranch(refreshedStack));

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -1132,6 +1132,7 @@ async function publishApprovedIssue(issue: CompletedIssue): Promise<void> {
     retargetStackPrIfNeeded(issue, publishDecision.existingPr.url);
     console.log(`  updated existing PR on ${publishDecision.existingPr.headRefName}: ${publishDecision.existingPr.url}`);
     recordPublishedStackPosition(issue, publishDecision.existingPr.url);
+    rebasePublishedStackDownstreamOpenPrs(issue);
     if (declarePendingPebbleClosure(issue.id, publishDecision.existingPr.url)) {
       markIssueInReview(issue.id);
     }
@@ -1157,6 +1158,7 @@ async function publishApprovedIssue(issue: CompletedIssue): Promise<void> {
   }
 
   recordPublishedStackPosition(issue, prRef);
+  rebasePublishedStackDownstreamOpenPrs(issue);
   if (declarePendingPebbleClosure(issue.id, prRef)) {
     markIssueInReview(issue.id);
   }
@@ -1248,6 +1250,7 @@ async function publishCompletedIssues(
       retargetStackPrIfNeeded(issue, publishDecision.existingPr.url);
       console.log(`  updated existing PR on ${publishDecision.existingPr.headRefName}: ${publishDecision.existingPr.url}`);
       recordPublishedStackPosition(issue, publishDecision.existingPr.url);
+      rebasePublishedStackDownstreamOpenPrs(issue);
       if (declarePendingPebbleClosure(issue.id, publishDecision.existingPr.url)) {
         markIssueInReview(issue.id);
       }
@@ -1262,6 +1265,7 @@ async function publishCompletedIssues(
       const prRef = extractPrRef(prCreate.stdout) || extractPrRef(prCreate.stderr);
       if (prRef) {
         recordPublishedStackPosition(issue, prRef);
+        rebasePublishedStackDownstreamOpenPrs(issue);
         if (declarePendingPebbleClosure(issue.id, prRef)) {
           markIssueInReview(issue.id);
         }
@@ -1765,6 +1769,55 @@ function rebaseStackOntoExpectedBases(stack: CompletedIssue[]): void {
 function rebaseIssueStackBranchIfNeeded(issue: CompletedIssue): void {
   if (!issue.stack) return;
   rebaseBranchWorktree(issue.worktreePath, issue.branch, effectiveBaseBranch(issue));
+}
+
+function rebasePublishedStackDownstreamOpenPrs(issue: CompletedIssue): void {
+  if (!issue.stack || !OPEN_PRS) return;
+  const openPrs = loadOpenStackPrRecords("open GitHub stack PR list for downstream stack rebase");
+  const entries = openPrs
+    .map((pr) => ({ pr, stack: parseStackMetadataFromBody(pr.body) }))
+    .filter((entry): entry is { pr: StackPrRecord; stack: StackMetadata } => entry.stack?.stackId === issue.stack!.stackId);
+
+  const publishedIndex = entries.findIndex((entry) => entry.pr.headRefName === issue.branch);
+  if (publishedIndex >= 0) {
+    entries[publishedIndex] = { ...entries[publishedIndex]!, stack: issue.stack };
+  } else {
+    entries.push({ pr: { headRefName: issue.branch }, stack: issue.stack });
+  }
+
+  entries.sort((a, b) => a.stack.index - b.stack.index || a.pr.headRefName.localeCompare(b.pr.headRefName));
+  const start = entries.findIndex((entry) => entry.pr.headRefName === issue.branch);
+  if (start < 0 || start >= entries.length - 1) return;
+
+  for (let index = start + 1; index < entries.length; index += 1) {
+    const entry = entries[index]!;
+    const refreshedStack = relinkStackMetadata(entry.stack, {
+      baseBranch: issue.stack.baseBranch,
+      headBranch: entry.pr.headRefName,
+      previousBranch: entries[index - 1]?.pr.headRefName,
+      nextBranch: entries[index + 1]?.pr.headRefName,
+    });
+    const expectedBase = stackBaseBranch(refreshedStack);
+    if (isDirtyExistingStackWorktree(entry.pr.headRefName)) {
+      logStackReconcileDeferred(entry.pr.headRefName, expectedBase);
+      break;
+    }
+    applyStackRetargetAction({
+      prRef: entry.pr.url || (entry.pr.number ? String(entry.pr.number) : entry.pr.headRefName),
+      headRefName: entry.pr.headRefName,
+      currentBase: entry.pr.baseRefName,
+      expectedBase,
+      stack: refreshedStack,
+      currentBody: entry.pr.body,
+      updateBase: Boolean(entry.pr.baseRefName && entry.pr.baseRefName !== expectedBase),
+      updateBody: !stackMetadataEqual(entry.stack, refreshedStack),
+    }, { rebaseBranch: true });
+  }
+}
+
+function isDirtyExistingStackWorktree(branch: string): boolean {
+  const worktree = collectWorktreeEntries().find((entry) => entry.branch === branch && existsSync(entry.path));
+  return Boolean(worktree && run("git status --porcelain", worktree.path).stdout.trim());
 }
 
 function rebaseOpenStackPrBranch(branch: string, expectedBase: string): { worktreePath: string; rebased: boolean } {

--- a/pi/picastle/main.mts
+++ b/pi/picastle/main.mts
@@ -550,7 +550,7 @@ function reconcileOpenStackPrs(options: { readOnly?: boolean } = {}, dirtyBranch
         upstreamRebased = false;
         continue;
       }
-      upstreamRebased = rebaseOpenStackPrBranch(entry.pr.headRefName, stackBaseBranch(refreshedStack)).rebased || upstreamRebased;
+      upstreamRebased = rebaseOpenStackPrBranch(entry.pr.headRefName, stackBaseBranch(refreshedStack), refreshedStack).rebased || upstreamRebased;
     }
   }
 
@@ -578,7 +578,7 @@ function logStackRetargetAction(action: StackRetargetAction, readOnly = false): 
 function applyStackRetargetAction(action: StackRetargetAction, options: { rebaseBranch?: boolean } = {}): boolean {
   logStackRetargetAction(action);
   const result = action.updateBase || action.effectiveBaseChanged || options.rebaseBranch
-    ? rebaseOpenStackPrBranch(action.headRefName, action.expectedBase)
+    ? rebaseOpenStackPrBranch(action.headRefName, action.expectedBase, action.stack)
     : { worktreePath: ensureExistingBranchWorktree(action.headRefName), rebased: false };
   persistStackMetadata(action.stack);
   const bodyFile = writeStackPrBodyRefreshFile(action);
@@ -604,9 +604,27 @@ function openStackPrGroups(openPrs: StackPrRecord[]): Array<Array<{ pr: StackPrR
 }
 
 function persistStackMetadata(stack: StackMetadata): void {
-  assertSafeRecoveryBranchName(stack.headBranch);
+  const refreshedStack = refreshStackHeadSha(stack);
+  assertSafeRecoveryBranchName(refreshedStack.headBranch);
   mkdirSync(stackMetadataDir, { recursive: true });
-  writeFileSync(stackMetadataPath(stack.headBranch), JSON.stringify(stack, null, 2));
+  writeFileSync(stackMetadataPath(refreshedStack.headBranch), JSON.stringify(refreshedStack, null, 2));
+}
+
+function refreshStackHeadSha(stack: StackMetadata): StackMetadata {
+  const refreshed = { ...stack };
+  if (!refreshed.previousBranch) {
+    delete refreshed.previousHeadSha;
+    return refreshed;
+  }
+  const previousHeadSha = resolveCommitSha(refreshed.previousBranch);
+  if (previousHeadSha) refreshed.previousHeadSha = previousHeadSha;
+  return refreshed;
+}
+
+function resolveCommitSha(ref: string): string | undefined {
+  if (ref !== BASE_BRANCH && !isRecognizedRecoveryPrHead(ref)) return undefined;
+  const result = run(`git rev-parse --verify --quiet ${shellQuote(`${ref}^{commit}`)}`, repoRoot, { allowFailure: true });
+  return result.status === 0 ? result.stdout.trim() || undefined : undefined;
 }
 
 function loadPersistedStackMetadata(branch: string): StackMetadata | undefined {
@@ -1579,7 +1597,7 @@ function writePrBodyFile(issue: CompletedIssue): string {
 function writeStackPrBodyRefreshFile(action: StackRetargetAction): string {
   const bodyFile = join(logsDir, `pr-body-stack-refresh-${hashString(action.headRefName)}.md`);
   mkdirSync(dirname(bodyFile), { recursive: true });
-  writeFileSync(bodyFile, upsertStackPrBodySection(action.currentBody, action.stack));
+  writeFileSync(bodyFile, upsertStackPrBodySection(action.currentBody, refreshStackHeadSha(action.stack)));
   return bodyFile;
 }
 
@@ -1608,7 +1626,7 @@ function postPebblesComment(worktreePath: string, issueId: string, body: string)
 }
 
 function buildPrBody(issue: CompletedIssue): string {
-  const stackSection = stackPrBodySection(issue.stack);
+  const stackSection = stackPrBodySection(issue.stack ? refreshStackHeadSha(issue.stack) : undefined);
   return `> *This PR was produced by an autonomous Picastle run from the agent brief on pebbles issue ${issue.id}.*
 
 ${stackSection}## Summary
@@ -1778,7 +1796,10 @@ function rebaseStackOntoExpectedBases(stack: CompletedIssue[]): void {
 
 function rebaseIssueStackBranchIfNeeded(issue: CompletedIssue): void {
   if (!issue.stack) return;
-  rebaseBranchWorktree(issue.worktreePath, issue.branch, effectiveBaseBranch(issue));
+  rebaseBranchWorktree(issue.worktreePath, issue.branch, effectiveBaseBranch(issue), {
+    oldUpstream: issue.stack.previousHeadSha,
+  });
+  persistStackMetadata(issue.stack);
 }
 
 function rebasePublishedStackDownstreamOpenPrs(issue: CompletedIssue): void {
@@ -1831,9 +1852,11 @@ function isDirtyExistingStackWorktree(branch: string): boolean {
   return Boolean(worktree && run("git status --porcelain", worktree.path).stdout.trim());
 }
 
-function rebaseOpenStackPrBranch(branch: string, expectedBase: string): { worktreePath: string; rebased: boolean } {
+function rebaseOpenStackPrBranch(branch: string, expectedBase: string, stack?: StackMetadata): { worktreePath: string; rebased: boolean } {
   const worktreePath = ensureExistingBranchWorktree(branch);
-  const rebased = rebaseBranchWorktree(worktreePath, branch, expectedBase);
+  const rebased = rebaseBranchWorktree(worktreePath, branch, expectedBase, {
+    oldUpstream: stack?.previousHeadSha,
+  });
   if (!rebased) return { worktreePath, rebased: false };
   if (!PUSH) {
     console.log("PICASTLE_PUSH=0; skipping force-with-lease update after stack rebase");
@@ -1858,7 +1881,12 @@ function ensureExistingBranchWorktree(branch: string): string {
   return ensureBranchWorktree(branch);
 }
 
-function rebaseBranchWorktree(worktreePath: string, branch: string, base: string): boolean {
+function rebaseBranchWorktree(
+  worktreePath: string,
+  branch: string,
+  base: string,
+  options: { oldUpstream?: string } = {},
+): boolean {
   assertSafeRecoveryBranchName(branch);
   ensureLocalRebaseBase(base);
   const ancestor = run(`git merge-base --is-ancestor ${shellQuote(base)} ${shellQuote(branch)}`, repoRoot, {
@@ -1869,13 +1897,30 @@ function rebaseBranchWorktree(worktreePath: string, branch: string, base: string
   const dirty = run("git status --porcelain", worktreePath).stdout.trim();
   if (dirty) throw new Error(`refusing to rebase dirty stack worktree ${branch}`);
 
+  const oldUpstream = resolveSafeRebaseBoundary(options.oldUpstream, branch);
   console.log(`  rebasing stack branch ${branch} onto ${base}`);
-  const rebase = run(`git rebase ${shellQuote(base)}`, worktreePath, { allowFailure: true });
+  const command = oldUpstream
+    ? `git rebase --onto ${shellQuote(base)} ${shellQuote(oldUpstream)} ${shellQuote(branch)}`
+    : `git rebase ${shellQuote(base)}`;
+  const rebase = run(command, worktreePath, { allowFailure: true });
   if (rebase.status !== 0) {
     run("git rebase --abort", worktreePath, { allowFailure: true });
     throw new Error(`failed to rebase stack branch ${branch} onto ${base}: ${rebase.stderr || rebase.stdout}`);
   }
   return true;
+}
+
+function resolveSafeRebaseBoundary(oldUpstream: string | undefined, branch: string): string | undefined {
+  if (!oldUpstream) return undefined;
+  if (!/^[0-9a-f]{7,40}$/i.test(oldUpstream)) return undefined;
+  const exists = run(`git rev-parse --verify --quiet ${shellQuote(`${oldUpstream}^{commit}`)}`, repoRoot, {
+    allowFailure: true,
+  }).status === 0;
+  if (!exists) return undefined;
+  const ancestor = run(`git merge-base --is-ancestor ${shellQuote(oldUpstream)} ${shellQuote(branch)}`, repoRoot, {
+    allowFailure: true,
+  });
+  return ancestor.status === 0 ? oldUpstream : undefined;
 }
 
 function ensureLocalRebaseBase(base: string): void {

--- a/pi/picastle/package.json
+++ b/pi/picastle/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "typecheck": "tsc main.mts review-session.mts review-tools.mts --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --allowImportingTsExtensions",
-    "test": "tsx --test review-tools.test.mts recovery.test.mts scripts/planner-output.test.mts",
+    "test": "tsx --test stack.test.mts review-tools.test.mts recovery.test.mts scripts/planner-output.test.mts",
     "prep": "bash scripts/prep.sh",
     "start": "tsx main.mts"
   },

--- a/pi/picastle/prompts/implement-prompt.md
+++ b/pi/picastle/prompts/implement-prompt.md
@@ -8,6 +8,8 @@ You are running through Picastle, a Pi SDK host-worktree orchestrator. This is n
 
 Base branch: `{{BASE_BRANCH}}`
 
+{{STACK_CONTEXT}}
+
 Only work on this issue.
 
 # ISSUE

--- a/pi/picastle/recovery.mts
+++ b/pi/picastle/recovery.mts
@@ -7,7 +7,9 @@ export type RepositoryIdentity = { owner: string; name: string };
 export type OpenPrRecord = {
   number?: number;
   headRefName: string;
+  baseRefName?: string;
   url: string;
+  body?: string;
   isCrossRepository?: boolean;
   headRepositoryOwner?: string;
   headRepositoryName?: string;
@@ -523,7 +525,9 @@ function parseOpenPrRecords(stdout: string, options: OpenPrParseOptions = {}): O
     return {
       ...(Number.isFinite(number) ? { number } : {}),
       headRefName: record.headRefName,
+      ...(typeof record.baseRefName === "string" && record.baseRefName.length > 0 ? { baseRefName: record.baseRefName } : {}),
       url: record.url,
+      ...(typeof record.body === "string" ? { body: record.body } : {}),
       ...(typeof record.isCrossRepository === "boolean" ? { isCrossRepository: record.isCrossRepository } : {}),
       ...extractHeadRepositoryIdentity(record),
     };

--- a/pi/picastle/recovery.mts
+++ b/pi/picastle/recovery.mts
@@ -1,3 +1,5 @@
+import type { StackMetadata } from "./stack.mjs";
+
 export type RecoveryIssueLookup =
   | { state: "found" }
   | { state: "not_found"; message?: string }
@@ -47,6 +49,7 @@ export type RecoveryBranchInput = {
   worktreePath?: string;
   openPrUrl?: string;
   commitTime?: number;
+  stack?: StackMetadata;
 };
 
 export type RecoveryReadinessPolicy = {
@@ -61,6 +64,7 @@ export type RecoveryIssue = {
   title: string;
   branch: string;
   worktreePath?: string;
+  stack?: StackMetadata;
 };
 
 export type RecoveryBranchDecision = RecoveryBranchInput & {
@@ -189,7 +193,7 @@ export function buildRecoveryPlan(
     }
 
     if (branch.openPrUrl && !branch.dirty && unpushed === 0) {
-      plan.alreadyPublished.push({ id: issueId, title, branch: branch.branch, worktreePath: branch.worktreePath, prUrl: branch.openPrUrl });
+      plan.alreadyPublished.push({ id: issueId, title, branch: branch.branch, worktreePath: branch.worktreePath, ...(branch.stack ? { stack: branch.stack } : {}), prUrl: branch.openPrUrl });
       plan.blockedIssueIds.add(issueId);
       continue;
     }
@@ -222,6 +226,7 @@ export function buildRecoveryPlan(
       title: selected.title ?? selected.issueId,
       branch: selected.branch,
       worktreePath: selected.worktreePath,
+      ...(selected.stack ? { stack: selected.stack } : {}),
     };
     if (selected.dirty) {
       plan.interruptedImplementations.push(issue);
@@ -640,6 +645,9 @@ function compareRecoveryCandidates(a: RecoveryBranchDecision, b: RecoveryBranchD
 }
 
 function compareRecoveryIssues(a: RecoveryIssue, b: RecoveryIssue): number {
+  if (a.stack?.stackId && a.stack.stackId === b.stack?.stackId) {
+    return a.stack.index - b.stack.index || a.id.localeCompare(b.id) || a.branch.localeCompare(b.branch);
+  }
   return a.id.localeCompare(b.id) || a.branch.localeCompare(b.branch);
 }
 

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -30,6 +30,7 @@ import {
   validatePlannedIssueSelections,
   type RecoveryBranchInput,
 } from "./recovery.mjs";
+import type { StackMetadata } from "./stack.mjs";
 
 test("extracts pebble ids before realistic branch slugs during recovery", () => {
   assert.equal(extractIssueIdFromBranch("picastle/ricekit-394-fix-old"), "ricekit-394");
@@ -355,6 +356,53 @@ test("does not treat open PR branches as already published when pebble lookup is
   ]);
   assert.equal(plan.blockedIssueIds.has("dotfiles-yi5"), true);
   assert.equal(plan.blockedIssueIds.has("dotfiles-zzz"), true);
+});
+
+test("recovery preserves persisted stack order instead of issue-id sort", () => {
+  const stack = (index: number, issueId: string, headBranch: string, previousBranch?: string): StackMetadata => ({
+    stackId: "dotfiles-zzz-dotfiles-aaa-dotfiles-mmm",
+    index,
+    total: 3,
+    issueId,
+    headBranch,
+    baseBranch: "main",
+    ...(previousBranch ? { previousBranch } : {}),
+  });
+  const plan = buildRecoveryPlan(
+    [
+      {
+        branch: "picastle/dotfiles-aaa-second",
+        issueId: "dotfiles-aaa",
+        title: "Second in planner order",
+        issueStatus: "ready_for_agent",
+        ahead: 1,
+        dirty: false,
+        stack: stack(2, "dotfiles-aaa", "picastle/dotfiles-aaa-second", "picastle/dotfiles-zzz-first"),
+      },
+      {
+        branch: "picastle/dotfiles-mmm-third",
+        issueId: "dotfiles-mmm",
+        title: "Third in planner order",
+        issueStatus: "ready_for_agent",
+        ahead: 1,
+        dirty: false,
+        stack: stack(3, "dotfiles-mmm", "picastle/dotfiles-mmm-third", "picastle/dotfiles-aaa-second"),
+      },
+      {
+        branch: "picastle/dotfiles-zzz-first",
+        issueId: "dotfiles-zzz",
+        title: "First in planner order",
+        issueStatus: "ready_for_agent",
+        ahead: 1,
+        dirty: false,
+        stack: stack(1, "dotfiles-zzz", "picastle/dotfiles-zzz-first"),
+      },
+    ],
+    "ready_for_agent",
+  );
+
+  assert.deepEqual(plan.unpublishedBranches.map((issue) => issue.id), ["dotfiles-zzz", "dotfiles-aaa", "dotfiles-mmm"]);
+  assert.equal(plan.unpublishedBranches[1]!.stack?.previousBranch, "picastle/dotfiles-zzz-first");
 });
 
 test("recovery treats legacy open issues with the policy ready label as ready", () => {
@@ -1573,6 +1621,249 @@ exit 1
   assert.match(pebTrace, /comment add dotfiles-bbb Picastle published stacked PR 2\/3/);
   assert.match(pebTrace, /comment add dotfiles-ccc Picastle published stacked PR 3\/3/);
 });
+
+test("stack recovery republishes in persisted stack order with original bases", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stacked-recovery-order-"));
+  const repo = join(tempRoot, "repo");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], {
+    cwd: repo,
+    encoding: "utf8",
+  });
+
+  const branches = [
+    ["picastle/dotfiles-zzz-first", "z.txt", "dotfiles-zzz"],
+    ["picastle/dotfiles-aaa-second", "a.txt", "dotfiles-aaa"],
+    ["picastle/dotfiles-mmm-third", "m.txt", "dotfiles-mmm"],
+  ] as const;
+  for (const [branch, file, issueId] of branches) {
+    execFileSync("git", ["checkout", "-b", branch], { cwd: repo, encoding: "utf8" });
+    writeFileSync(join(repo, file), `${issueId}\n`);
+    execFileSync("git", ["add", file], { cwd: repo, encoding: "utf8" });
+    execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", `${issueId}\n\nCloses: ${issueId}`], {
+      cwd: repo,
+      encoding: "utf8",
+    });
+  }
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+
+  const xdgCache = join(tempRoot, "cache");
+  const stackDir = join(xdgCache, "picastle", safeRepoIdForTest(realpathSync(repo)), "stacks");
+  mkdirSync(stackDir, { recursive: true });
+  const stackId = "dotfiles-zzz-dotfiles-aaa-dotfiles-mmm";
+  const metadata = branches.map(([branch, , issueId], index) => ({
+    stackId,
+    index: index + 1,
+    total: branches.length,
+    issueId,
+    headBranch: branch,
+    baseBranch: "main",
+    ...(index > 0 ? { previousBranch: branches[index - 1]![0] } : {}),
+    ...(index < branches.length - 1 ? { nextBranch: branches[index + 1]![0] } : {}),
+  }));
+  for (const stack of metadata) {
+    writeFileSync(join(stackDir, `${hashStringForTest(stack.headBranch)}.json`), JSON.stringify(stack));
+  }
+
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+
+  const gh = join(fakeBin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then
+  printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'
+  exit 0
+fi
+if [[ "$1 $2" == "pr list" ]]; then
+  printf '%s\n' '[]'
+  exit 0
+fi
+if [[ "$1 $2" == "pr create" ]]; then
+  args=" $* "
+  if [[ "$args" == *" --base main "* && "$args" == *" --head picastle/dotfiles-zzz-first "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/10'
+    exit 0
+  fi
+  if [[ "$args" == *" --base picastle/dotfiles-zzz-first "* && "$args" == *" --head picastle/dotfiles-aaa-second "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/11'
+    exit 0
+  fi
+  if [[ "$args" == *" --base picastle/dotfiles-aaa-second "* && "$args" == *" --head picastle/dotfiles-mmm-third "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/12'
+    exit 0
+  fi
+  echo "unexpected recovered stacked gh pr create invocation: $*" >&2
+  exit 2
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(gh, 0o755);
+
+  const peb = join(fakeBin, "peb");
+  writeFileSync(
+    peb,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then
+  printf '%s\n' '{"data":[{"id":"dotfiles-aaa"},{"id":"dotfiles-mmm"},{"id":"dotfiles-zzz"}]}'
+  exit 0
+fi
+if [[ "$1" == "show" ]]; then
+  case "$2" in
+    dotfiles-aaa) printf '%s\n' '{"data":{"title":"Second","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-mmm) printf '%s\n' '{"data":{"title":"Third","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-zzz) printf '%s\n' '{"data":{"title":"First","status":"ready_for_agent"}}'; exit 0 ;;
+  esac
+fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then
+  printf '%s\n' 'ok'
+  exit 0
+fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: xdgCache,
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_PUBLISHER_AGENT: "0",
+      PICASTLE_PUSH: "0",
+      PICASTLE_VERIFY: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /Recovery has unpublished local branches/);
+  const ghTrace = readFileSync(ghLog, "utf8");
+  assert.match(ghTrace, /pr create --base main --head picastle\/dotfiles-zzz-first/);
+  assert.match(ghTrace, /pr create --base picastle\/dotfiles-zzz-first --head picastle\/dotfiles-aaa-second/);
+  assert.match(ghTrace, /pr create --base picastle\/dotfiles-aaa-second --head picastle\/dotfiles-mmm-third/);
+});
+
+test("stack reconciliation rebases downstream branches before retargeting merged upstream PRs", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-rebase-"));
+  const repo = join(tempRoot, "repo");
+  const origin = join(tempRoot, "origin.git");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--bare", origin], { encoding: "utf8" });
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "dotfiles-aaa"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "downstream\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "dotfiles-bbb"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "squash upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+
+  const stackBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId: "dotfiles-aaa-dotfiles-bbb",
+    index: 2,
+    total: 2,
+    issueId: "dotfiles-bbb",
+    headBranch: "picastle/dotfiles-bbb-downstream",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-aaa-upstream",
+  })}\n-->`;
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+  const gh = join(fakeBin, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then cat <<'JSON'
+[{"number":22,"headRefName":"picastle/dotfiles-bbb-downstream","baseRefName":"picastle/dotfiles-aaa-upstream","url":"https://github.com/acme/repo/pull/22","body":${JSON.stringify(stackBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]
+JSON
+exit 0; fi
+if [[ "$1 $2" == "pr edit" ]]; then exit 0; fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+  const peb = join(fakeBin, "peb");
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb"}]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Downstream","status":"ready_for_agent"}}'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" ]]; then printf '%s\n' 'ok'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_MAX_ISSUES: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /rebasing stack branch picastle\/dotfiles-bbb-downstream onto main/);
+  assert.doesNotThrow(() => execFileSync("git", ["merge-base", "--is-ancestor", "main", "picastle/dotfiles-bbb-downstream"], { cwd: repo }));
+  assert.equal(execFileSync("git", ["rev-parse", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }), execFileSync("git", ["rev-parse", "origin/picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }));
+  assert.match(readFileSync(ghLog, "utf8"), /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
+});
+
+function hashStringForTest(input: string): string {
+  let hash = 5381;
+  for (const char of input) hash = ((hash << 5) + hash + char.charCodeAt(0)) >>> 0;
+  return hash.toString(36);
+}
+
+function safeRepoIdForTest(root: string): string {
+  return root.replace(/^\//, "").replace(/[^a-zA-Z0-9._-]+/g, "-");
+}
 
 test("runtime recovery fails closed on malformed open PR discovery without mutating pebbles", () => {
   const packageDir = dirname(fileURLToPath(import.meta.url));

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -1622,6 +1622,281 @@ exit 1
   assert.match(pebTrace, /comment add dotfiles-ccc Picastle published stacked PR 3\/3/);
 });
 
+test("stack recovery relinks publishable entries when the first stack branch has no commits", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stacked-empty-first-"));
+  const repo = join(tempRoot, "repo");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], {
+    cwd: repo,
+    encoding: "utf8",
+  });
+
+  const branches = [
+    ["picastle/dotfiles-aaa-empty", undefined, "dotfiles-aaa"],
+    ["picastle/dotfiles-bbb-second", "b.txt", "dotfiles-bbb"],
+    ["picastle/dotfiles-ccc-third", "c.txt", "dotfiles-ccc"],
+  ] as const;
+  execFileSync("git", ["checkout", "-b", branches[0]![0]], { cwd: repo, encoding: "utf8" });
+  for (const [branch, file, issueId] of branches.slice(1)) {
+    execFileSync("git", ["checkout", "-b", branch], { cwd: repo, encoding: "utf8" });
+    writeFileSync(join(repo, file!), `${issueId}\n`);
+    execFileSync("git", ["add", file!], { cwd: repo, encoding: "utf8" });
+    execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", `${issueId}\n\nCloses: ${issueId}`], {
+      cwd: repo,
+      encoding: "utf8",
+    });
+  }
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+
+  const xdgCache = join(tempRoot, "cache");
+  const stackDir = join(xdgCache, "picastle", safeRepoIdForTest(realpathSync(repo)), "stacks");
+  mkdirSync(stackDir, { recursive: true });
+  const stackId = "dotfiles-aaa-dotfiles-bbb-dotfiles-ccc";
+  const metadata = branches.map(([branch, , issueId], index) => ({
+    stackId,
+    index: index + 1,
+    total: branches.length,
+    issueId,
+    headBranch: branch,
+    baseBranch: "main",
+    ...(index > 0 ? { previousBranch: branches[index - 1]![0] } : {}),
+    ...(index < branches.length - 1 ? { nextBranch: branches[index + 1]![0] } : {}),
+  }));
+  for (const stack of metadata) {
+    writeFileSync(join(stackDir, `${hashStringForTest(stack.headBranch)}.json`), JSON.stringify(stack));
+  }
+
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+
+  const gh = join(fakeBin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then
+  printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'
+  exit 0
+fi
+if [[ "$1 $2" == "pr list" ]]; then
+  printf '%s\n' '[]'
+  exit 0
+fi
+if [[ "$1 $2" == "pr create" ]]; then
+  args=" $* "
+  if [[ "$args" == *" --head picastle/dotfiles-aaa-empty "* ]]; then
+    echo "empty first stack branch should not be published" >&2
+    exit 2
+  fi
+  if [[ "$args" == *" --base main "* && "$args" == *" --head picastle/dotfiles-bbb-second "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/21'
+    exit 0
+  fi
+  if [[ "$args" == *" --base picastle/dotfiles-bbb-second "* && "$args" == *" --head picastle/dotfiles-ccc-third "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/22'
+    exit 0
+  fi
+  echo "unexpected relinked stacked gh pr create invocation: $*" >&2
+  exit 2
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(gh, 0o755);
+
+  const peb = join(fakeBin, "peb");
+  writeFileSync(
+    peb,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then
+  printf '%s\n' '{"data":[{"id":"dotfiles-aaa"},{"id":"dotfiles-bbb"},{"id":"dotfiles-ccc"}]}'
+  exit 0
+fi
+if [[ "$1" == "show" ]]; then
+  case "$2" in
+    dotfiles-aaa) printf '%s\n' '{"data":{"title":"Empty first","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-bbb) printf '%s\n' '{"data":{"title":"Second","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-ccc) printf '%s\n' '{"data":{"title":"Third","status":"ready_for_agent"}}'; exit 0 ;;
+  esac
+fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then
+  printf '%s\n' 'ok'
+  exit 0
+fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: xdgCache,
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_PUBLISHER_AGENT: "0",
+      PICASTLE_PUSH: "0",
+      PICASTLE_VERIFY: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /Recovery has unpublished local branches/);
+  assert.match(output, /stack metadata refresh: picastle\/dotfiles-bbb-second base main/);
+  const ghTrace = readFileSync(ghLog, "utf8");
+  assert.doesNotMatch(ghTrace, /pr create .*--head picastle\/dotfiles-aaa-empty/);
+  assert.match(ghTrace, /pr create --base main --head picastle\/dotfiles-bbb-second/);
+  assert.match(ghTrace, /pr create --base picastle\/dotfiles-bbb-second --head picastle\/dotfiles-ccc-third/);
+});
+
+test("stack recovery ignores downstream branches with no commits over their stack base", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stacked-empty-downstream-"));
+  const repo = join(tempRoot, "repo");
+  const origin = join(tempRoot, "origin.git");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--bare", origin], { encoding: "utf8" });
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "dotfiles-aaa\n\nCloses: dotfiles-aaa"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-empty"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+
+  const xdgCache = join(tempRoot, "cache");
+  const stackDir = join(xdgCache, "picastle", safeRepoIdForTest(realpathSync(repo)), "stacks");
+  mkdirSync(stackDir, { recursive: true });
+  const metadata = [
+    {
+      stackId: "dotfiles-aaa-dotfiles-bbb",
+      index: 1,
+      total: 2,
+      issueId: "dotfiles-aaa",
+      headBranch: "picastle/dotfiles-aaa-upstream",
+      baseBranch: "main",
+      nextBranch: "picastle/dotfiles-bbb-empty",
+    },
+    {
+      stackId: "dotfiles-aaa-dotfiles-bbb",
+      index: 2,
+      total: 2,
+      issueId: "dotfiles-bbb",
+      headBranch: "picastle/dotfiles-bbb-empty",
+      baseBranch: "main",
+      previousBranch: "picastle/dotfiles-aaa-upstream",
+    },
+  ];
+  for (const stack of metadata) {
+    writeFileSync(join(stackDir, `${hashStringForTest(stack.headBranch)}.json`), JSON.stringify(stack));
+  }
+
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+
+  const firstPrBody = `<!-- picastle-stack\n${JSON.stringify(metadata[0])}\n-->`;
+  const gh = join(fakeBin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then
+  printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'
+  exit 0
+fi
+if [[ "$1 $2" == "pr list" ]]; then
+  printf '%s\n' '[{"number":30,"headRefName":"picastle/dotfiles-aaa-upstream","baseRefName":"main","url":"https://github.com/acme/repo/pull/30","body":${JSON.stringify(firstPrBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]'
+  exit 0
+fi
+if [[ "$1 $2" == "pr create" ]]; then
+  echo "empty downstream branch should not be published" >&2
+  exit 2
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(gh, 0o755);
+
+  const peb = join(fakeBin, "peb");
+  writeFileSync(
+    peb,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then
+  printf '%s\n' '{"data":[{"id":"dotfiles-aaa"},{"id":"dotfiles-bbb"}]}'
+  exit 0
+fi
+if [[ "$1" == "show" ]]; then
+  case "$2" in
+    dotfiles-aaa) printf '%s\n' '{"data":{"title":"Upstream","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-bbb) printf '%s\n' '{"data":{"title":"Empty downstream","status":"ready_for_agent"}}'; exit 0 ;;
+  esac
+fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then
+  printf '%s\n' 'ok'
+  exit 0
+fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: xdgCache,
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_PUBLISHER_AGENT: "0",
+      PICASTLE_PUSH: "0",
+      PICASTLE_VERIFY: "0",
+      PICASTLE_STACK_PRS: "1",
+      PICASTLE_TEST_AGENT_OUTPUT: '<plan>{"issues":[]}</plan>',
+    },
+  });
+
+  assert.match(output, /0 unpublished, 1 already published, 0 deferred, 1 zero-ahead ignored/);
+  const ghTrace = readFileSync(ghLog, "utf8");
+  assert.doesNotMatch(ghTrace, /\bpr create\b/);
+  assert.doesNotMatch(output, /publish: dotfiles-bbb picastle\/dotfiles-bbb-empty/);
+});
+
 test("stack recovery republishes in persisted stack order with original bases", () => {
   const packageDir = dirname(fileURLToPath(import.meta.url));
   const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stacked-recovery-order-"));

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -6,6 +6,9 @@ import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+process.env.PICASTLE_WORKTREE_READY_COMMAND = "";
+process.env.PICASTLE_BEFORE_PUSH_COMMAND = "";
+
 import {
   assertSafeRecoveryBranchName,
   buildRecoveryPlan,
@@ -1440,6 +1443,135 @@ exit 1
   assert.match(pebTrace, /closes add web-api-abc --pr https:\/\/github\.com\/acme\/repo\/pull\/50/);
   assert.match(pebTrace, /closes add web-api --pr https:\/\/github\.com\/acme\/repo\/pull\/51/);
   assert.doesNotMatch(pebTrace, /closes add web-api --pr https:\/\/github\.com\/acme\/repo\/pull\/50/);
+});
+
+test("stacked publisher creates PRs against previous stack heads and records comments", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stacked-publish-"));
+  const repo = join(tempRoot, "repo");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], {
+    cwd: repo,
+    encoding: "utf8",
+  });
+
+  const branches = [
+    ["picastle/dotfiles-aaa-first", "a.txt", "dotfiles-aaa"],
+    ["picastle/dotfiles-bbb-second", "b.txt", "dotfiles-bbb"],
+    ["picastle/dotfiles-ccc-third", "c.txt", "dotfiles-ccc"],
+  ] as const;
+  for (const [branch, file, issueId] of branches) {
+    execFileSync("git", ["checkout", "-b", branch], { cwd: repo, encoding: "utf8" });
+    writeFileSync(join(repo, file), `${issueId}\n`);
+    execFileSync("git", ["add", file], { cwd: repo, encoding: "utf8" });
+    execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", `${issueId}\n\nCloses: ${issueId}`], {
+      cwd: repo,
+      encoding: "utf8",
+    });
+  }
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+
+  const gh = join(fakeBin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then
+  printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'
+  exit 0
+fi
+if [[ "$1 $2" == "pr list" ]]; then
+  printf '%s\n' '[]'
+  exit 0
+fi
+if [[ "$1 $2" == "pr create" ]]; then
+  args=" $* "
+  if [[ "$args" == *" --base main "* && "$args" == *" --head picastle/dotfiles-aaa-first "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/1'
+    exit 0
+  fi
+  if [[ "$args" == *" --base picastle/dotfiles-aaa-first "* && "$args" == *" --head picastle/dotfiles-bbb-second "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/2'
+    exit 0
+  fi
+  if [[ "$args" == *" --base picastle/dotfiles-bbb-second "* && "$args" == *" --head picastle/dotfiles-ccc-third "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/3'
+    exit 0
+  fi
+  echo "unexpected stacked gh pr create invocation: $*" >&2
+  exit 2
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(gh, 0o755);
+
+  const peb = join(fakeBin, "peb");
+  writeFileSync(
+    peb,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then
+  printf '%s\n' '{"data":[{"id":"dotfiles-aaa"},{"id":"dotfiles-bbb"},{"id":"dotfiles-ccc"}]}'
+  exit 0
+fi
+if [[ "$1" == "show" ]]; then
+  case "$2" in
+    dotfiles-aaa) printf '%s\n' '{"data":{"title":"First","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-bbb) printf '%s\n' '{"data":{"title":"Second","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-ccc) printf '%s\n' '{"data":{"title":"Third","status":"ready_for_agent"}}'; exit 0 ;;
+  esac
+fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then
+  printf '%s\n' 'ok'
+  exit 0
+fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_PUBLISHER_AGENT: "0",
+      PICASTLE_PUSH: "0",
+      PICASTLE_VERIFY: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /Stacked PR mode: enabled/);
+  assert.match(output, /verifying stacked PR mergeability for 3 branch\(es\)/);
+  const ghTrace = readFileSync(ghLog, "utf8");
+  assert.match(ghTrace, /pr create --base main --head picastle\/dotfiles-aaa-first/);
+  assert.match(ghTrace, /pr create --base picastle\/dotfiles-aaa-first --head picastle\/dotfiles-bbb-second/);
+  assert.match(ghTrace, /pr create --base picastle\/dotfiles-bbb-second --head picastle\/dotfiles-ccc-third/);
+  const pebTrace = readFileSync(pebLog, "utf8");
+  assert.match(pebTrace, /comment add dotfiles-aaa Picastle published stacked PR 1\/3/);
+  assert.match(pebTrace, /comment add dotfiles-bbb Picastle published stacked PR 2\/3/);
+  assert.match(pebTrace, /comment add dotfiles-ccc Picastle published stacked PR 3\/3/);
 });
 
 test("runtime recovery fails closed on malformed open PR discovery without mutating pebbles", () => {

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -2095,6 +2095,96 @@ exit 1
   assert.doesNotMatch(readFileSync(ghLog, "utf8"), /pr edit/);
 });
 
+test("mutable recovery defers dirty open downstream stack PR retargets", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-dirty-open-stack-mutable-"));
+  const repo = join(tempRoot, "repo");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "Picastle Test"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-aaa"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "downstream\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-bbb"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "squash upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "dirty.txt"), "uncommitted downstream repair\n");
+
+  const stackBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId: "dotfiles-aaa-dotfiles-bbb",
+    index: 2,
+    total: 2,
+    issueId: "dotfiles-bbb",
+    headBranch: "picastle/dotfiles-bbb-downstream",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-aaa-upstream",
+  })}\n-->`;
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+  const gh = join(fakeBin, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then cat <<'JSON'
+[{"number":22,"headRefName":"picastle/dotfiles-bbb-downstream","baseRefName":"picastle/dotfiles-aaa-upstream","url":"https://github.com/acme/repo/pull/22","body":${JSON.stringify(stackBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]
+JSON
+exit 0; fi
+if [[ "$1 $2" == "pr edit" ]]; then echo "dirty stack PR should not be edited during recovery reconcile" >&2; exit 7; fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+  const peb = join(fakeBin, "peb");
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Downstream","status":"in_review"}}'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const result = spawnSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_STACK_PRS: "1",
+      PICASTLE_TEST_AGENT_OUTPUT: '<plan>{"issues":[]}</plan>',
+    },
+  });
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.equal(result.status, 0, output);
+  assert.match(output, /defer: dotfiles-bbb picastle\/dotfiles-bbb-downstream: pebble status is in_review, not ready_for_agent/);
+  assert.match(output, /stack reconcile deferred: picastle\/dotfiles-bbb-downstream base main \(dirty worktree; recovery will resume it first\)/);
+  assert.doesNotMatch(output, /refusing to rebase dirty stack worktree/);
+  assert.doesNotMatch(readFileSync(ghLog, "utf8"), /pr edit/);
+});
+
 test("stack reconciliation rebases later downstream PRs after predecessor is rewritten", () => {
   const packageDir = dirname(fileURLToPath(import.meta.url));
   const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-cascade-rebase-"));

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -2656,7 +2656,7 @@ exit 1
 printf '%s\n' "$*" >> "$PEB_LOG"
 if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb"},{"id":"dotfiles-ccc"}]}'; exit 0; fi
 if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Stack entry","status":"ready_for_agent"}}'; exit 0; fi
-if [[ "$1 $2" == "closes add" || "$1" == "update" ]]; then printf '%s\n' 'ok'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then printf '%s\n' 'ok'; exit 0; fi
 echo "unexpected peb invocation: $*" >&2
 exit 1
 `);
@@ -2687,6 +2687,7 @@ exit 1
   const ghTrace = readFileSync(ghLog, "utf8");
   assert.match(ghTrace, /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
   assert.doesNotMatch(ghTrace, /pull\/33/);
+  assert.match(readFileSync(pebLog, "utf8"), /comment add dotfiles-bbb Picastle published stacked PR 2\/3/);
 });
 
 test("stack reconciliation rebases downstream branches before retargeting merged upstream PRs", () => {
@@ -2752,7 +2753,7 @@ exit 1
 printf '%s\n' "$*" >> "$PEB_LOG"
 if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb"}]}'; exit 0; fi
 if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Downstream","status":"ready_for_agent"}}'; exit 0; fi
-if [[ "$1 $2" == "closes add" || "$1" == "update" ]]; then printf '%s\n' 'ok'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then printf '%s\n' 'ok'; exit 0; fi
 echo "unexpected peb invocation: $*" >&2
 exit 1
 `);
@@ -2778,6 +2779,7 @@ exit 1
   assert.doesNotThrow(() => execFileSync("git", ["merge-base", "--is-ancestor", "main", "picastle/dotfiles-bbb-downstream"], { cwd: repo }));
   assert.equal(execFileSync("git", ["rev-parse", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }), execFileSync("git", ["rev-parse", "origin/picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }));
   assert.match(readFileSync(ghLog, "utf8"), /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
+  assert.match(readFileSync(pebLog, "utf8"), /comment add dotfiles-bbb Picastle published stacked PR 2\/2/);
 });
 
 test("interrupted dirty stack recovery resumes sequentially before downstream rebase", () => {

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -2095,6 +2095,120 @@ exit 1
   assert.doesNotMatch(readFileSync(ghLog, "utf8"), /pr edit/);
 });
 
+test("stack reconciliation rebases later downstream PRs after predecessor is rewritten", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-cascade-rebase-"));
+  const repo = join(tempRoot, "repo");
+  const origin = join(tempRoot, "origin.git");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--bare", origin], { encoding: "utf8" });
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "Picastle Test"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-aaa"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "middle\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-bbb"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "c.txt"), "tail\n");
+  execFileSync("git", ["add", "c.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-ccc"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "squash upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+
+  const stackId = "dotfiles-aaa-dotfiles-bbb-dotfiles-ccc";
+  const middleBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId,
+    index: 2,
+    total: 3,
+    issueId: "dotfiles-bbb",
+    headBranch: "picastle/dotfiles-bbb-middle",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-aaa-upstream",
+    nextBranch: "picastle/dotfiles-ccc-tail",
+  })}\n-->`;
+  const tailBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId,
+    index: 3,
+    total: 3,
+    issueId: "dotfiles-ccc",
+    headBranch: "picastle/dotfiles-ccc-tail",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-bbb-middle",
+  })}\n-->`;
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+  const gh = join(fakeBin, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then cat <<'JSON'
+[{"number":22,"headRefName":"picastle/dotfiles-bbb-middle","baseRefName":"picastle/dotfiles-aaa-upstream","url":"https://github.com/acme/repo/pull/22","body":${JSON.stringify(middleBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}},{"number":33,"headRefName":"picastle/dotfiles-ccc-tail","baseRefName":"picastle/dotfiles-bbb-middle","url":"https://github.com/acme/repo/pull/33","body":${JSON.stringify(tailBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]
+JSON
+exit 0; fi
+if [[ "$1 $2" == "pr edit" ]]; then exit 0; fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+  const peb = join(fakeBin, "peb");
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb"},{"id":"dotfiles-ccc"}]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Stack entry","status":"ready_for_agent"}}'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" ]]; then printf '%s\n' 'ok'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_MAX_ISSUES: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /stack retarget: picastle\/dotfiles-bbb-middle base picastle\/dotfiles-aaa-upstream → main/);
+  assert.match(output, /rebasing stack branch picastle\/dotfiles-bbb-middle onto main/);
+  assert.match(output, /rebasing stack branch picastle\/dotfiles-ccc-tail onto picastle\/dotfiles-bbb-middle/);
+  assert.doesNotThrow(() => execFileSync("git", ["merge-base", "--is-ancestor", "picastle/dotfiles-bbb-middle", "picastle/dotfiles-ccc-tail"], { cwd: repo }));
+  assert.equal(execFileSync("git", ["rev-parse", "picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" }), execFileSync("git", ["rev-parse", "origin/picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" }));
+  assert.equal(execFileSync("git", ["rev-parse", "picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" }), execFileSync("git", ["rev-parse", "origin/picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" }));
+  const ghTrace = readFileSync(ghLog, "utf8");
+  assert.match(ghTrace, /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
+  assert.doesNotMatch(ghTrace, /pull\/33/);
+});
+
 test("stack reconciliation rebases downstream branches before retargeting merged upstream PRs", () => {
   const packageDir = dirname(fileURLToPath(import.meta.url));
   const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-rebase-"));

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -30,7 +30,7 @@ import {
   validatePlannedIssueSelections,
   type RecoveryBranchInput,
 } from "./recovery.mjs";
-import type { StackMetadata } from "./stack.mjs";
+import { parseStackMetadataFromBody, type StackMetadata } from "./stack.mjs";
 
 test("extracts pebble ids before realistic branch slugs during recovery", () => {
   assert.equal(extractIssueIdFromBranch("picastle/ricekit-394-fix-old"), "ricekit-394");
@@ -2668,6 +2668,7 @@ exit 1
 `);
   chmodSync(peb, 0o755);
 
+  const xdgCache = join(tempRoot, "cache");
   const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
     cwd: packageDir,
     encoding: "utf8",
@@ -2676,7 +2677,7 @@ exit 1
       PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
       GH_LOG: ghLog,
       PEB_LOG: pebLog,
-      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      XDG_CACHE_HOME: xdgCache,
       PICASTLE_PEB_REMOTE: "",
       PICASTLE_PEB_REPO: "",
       PICASTLE_MAX_ISSUES: "0",
@@ -2692,8 +2693,66 @@ exit 1
   assert.equal(execFileSync("git", ["rev-parse", "picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" }), execFileSync("git", ["rev-parse", "origin/picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" }));
   const ghTrace = readFileSync(ghLog, "utf8");
   assert.match(ghTrace, /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
-  assert.doesNotMatch(ghTrace, /pull\/33/);
+  assert.match(ghTrace, /pr edit https:\/\/github\.com\/acme\/repo\/pull\/33 --body-file /);
   assert.match(readFileSync(pebLog, "utf8"), /comment add dotfiles-bbb Picastle published stacked PR 2\/3/);
+  const tailBodyFile = ghTrace.match(/pr edit https:\/\/github\.com\/acme\/repo\/pull\/33 --body-file (\S+)/)?.[1];
+  assert.ok(tailBodyFile);
+  const refreshedTailBody = readFileSync(tailBodyFile, "utf8");
+  const refreshedTailStack = parseStackMetadataFromBody(refreshedTailBody);
+  assert.equal(refreshedTailStack?.previousHeadSha, execFileSync("git", ["rev-parse", "picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" }).trim());
+
+  execFileSync("git", ["worktree", "remove", "--force", join(xdgCache, "picastle", safeRepoIdForTest(realpathSync(repo)), "worktrees", "dotfiles-bbb-middle")], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "middle squash differs\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "squash middle"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "origin", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(ghLog, "");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then cat <<'JSON'
+[{"number":33,"headRefName":"picastle/dotfiles-ccc-tail","baseRefName":"picastle/dotfiles-bbb-middle","url":"https://github.com/acme/repo/pull/33","body":${JSON.stringify(refreshedTailBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]
+JSON
+exit 0; fi
+if [[ "$1 $2" == "pr edit" ]]; then exit 0; fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" && "$2" == "--status" ]]; then printf '%s\n' '{"data":[]}'; exit 0; fi
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-ccc"}]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Tail","status":"ready_for_agent"}}'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then printf '%s\n' 'ok'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const secondOutput = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: xdgCache,
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_MAX_ISSUES: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+  assert.match(secondOutput, /stack retarget: picastle\/dotfiles-ccc-tail base picastle\/dotfiles-bbb-middle → main/);
+  assert.match(secondOutput, /rebasing stack branch picastle\/dotfiles-ccc-tail onto main/);
+  assert.deepEqual(
+    execFileSync("git", ["diff", "--name-only", "main...picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" }).trim().split("\n").filter(Boolean),
+    ["c.txt"],
+  );
 });
 
 test("stack reconciliation rebases downstream branches before retargeting merged upstream PRs", () => {

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -2788,6 +2788,112 @@ exit 1
   assert.match(readFileSync(pebLog, "utf8"), /comment add dotfiles-bbb Picastle published stacked PR 2\/2/);
 });
 
+test("stack reconciliation refreshes stale local base before rebasing downstream", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-stale-base-"));
+  const repo = join(tempRoot, "repo");
+  const origin = join(tempRoot, "origin.git");
+  const merger = join(tempRoot, "merger");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--bare", origin], { encoding: "utf8" });
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "Picastle Test"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-aaa"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "downstream\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-bbb"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["clone", "--branch", "main", origin, merger], { encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "Picastle Test"], { cwd: merger, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: merger, encoding: "utf8" });
+  writeFileSync(join(merger, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: merger, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "squash upstream"], { cwd: merger, encoding: "utf8" });
+  execFileSync("git", ["push", "origin", "main"], { cwd: merger, encoding: "utf8" });
+
+  const stackBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId: "dotfiles-aaa-dotfiles-bbb",
+    index: 2,
+    total: 2,
+    issueId: "dotfiles-bbb",
+    headBranch: "picastle/dotfiles-bbb-downstream",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-aaa-upstream",
+  })}\n-->`;
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+  const gh = join(fakeBin, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then cat <<'JSON'
+[{"number":22,"headRefName":"picastle/dotfiles-bbb-downstream","baseRefName":"picastle/dotfiles-aaa-upstream","url":"https://github.com/acme/repo/pull/22","body":${JSON.stringify(stackBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]
+JSON
+exit 0; fi
+if [[ "$1 $2" == "pr edit" ]]; then exit 0; fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+  const peb = join(fakeBin, "peb");
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb"}]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Downstream","status":"ready_for_agent"}}'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then printf '%s\n' 'ok'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_MAX_ISSUES: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /rebasing stack branch picastle\/dotfiles-bbb-downstream onto main/);
+  assert.doesNotThrow(() => execFileSync("git", ["merge-base", "--is-ancestor", "origin/main", "picastle/dotfiles-bbb-downstream"], { cwd: repo }));
+  assert.notEqual(
+    execFileSync("git", ["rev-parse", "main"], { cwd: repo, encoding: "utf8" }),
+    execFileSync("git", ["rev-parse", "origin/main"], { cwd: repo, encoding: "utf8" }),
+  );
+  assert.deepEqual(
+    execFileSync("git", ["diff", "--name-only", "origin/main...picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }).trim().split("\n").filter(Boolean),
+    ["b.txt"],
+  );
+  assert.match(readFileSync(ghLog, "utf8"), /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
+});
+
 test("stack reconciliation rebases downstream with old upstream boundary after multi-commit squash merge", () => {
   const packageDir = dirname(fileURLToPath(import.meta.url));
   const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-squash-boundary-"));

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -2665,6 +2665,143 @@ exit 1
   assert.match(readFileSync(ghLog, "utf8"), /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
 });
 
+test("interrupted dirty stack recovery resumes sequentially before downstream rebase", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stacked-interrupted-sequential-"));
+  const repo = join(tempRoot, "repo");
+  const fakeBin = join(tempRoot, "bin");
+  const worktrees = join(tempRoot, "worktrees");
+  mkdirSync(fakeBin, { recursive: true });
+  mkdirSync(worktrees, { recursive: true });
+
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], {
+    cwd: repo,
+    encoding: "utf8",
+  });
+
+  const firstBranch = "picastle/dotfiles-aaa-first";
+  const secondBranch = "picastle/dotfiles-bbb-second";
+  const firstWorktree = join(worktrees, "dotfiles-aaa-first");
+  const secondWorktree = join(worktrees, "dotfiles-bbb-second");
+  execFileSync("git", ["worktree", "add", "-b", firstBranch, firstWorktree, "main"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["worktree", "add", "-b", secondBranch, secondWorktree, firstBranch], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(firstWorktree, "a.txt"), "interrupted first\n");
+  writeFileSync(join(secondWorktree, "b.txt"), "interrupted second\n");
+
+  const xdgCache = join(tempRoot, "cache");
+  const stackDir = join(xdgCache, "picastle", safeRepoIdForTest(realpathSync(repo)), "stacks");
+  mkdirSync(stackDir, { recursive: true });
+  const metadata: StackMetadata[] = [
+    {
+      stackId: "dotfiles-aaa-dotfiles-bbb",
+      index: 1,
+      total: 2,
+      issueId: "dotfiles-aaa",
+      headBranch: firstBranch,
+      baseBranch: "main",
+      nextBranch: secondBranch,
+    },
+    {
+      stackId: "dotfiles-aaa-dotfiles-bbb",
+      index: 2,
+      total: 2,
+      issueId: "dotfiles-bbb",
+      headBranch: secondBranch,
+      baseBranch: "main",
+      previousBranch: firstBranch,
+    },
+  ];
+  for (const stack of metadata) {
+    writeFileSync(join(stackDir, `${hashStringForTest(stack.headBranch)}.json`), JSON.stringify(stack));
+  }
+
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+
+  const gh = join(fakeBin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+if [[ "$1 $2" == "repo view" ]]; then
+  printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'
+  exit 0
+fi
+if [[ "$1 $2" == "pr list" ]]; then
+  printf '%s\n' '[]'
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(gh, 0o755);
+
+  const peb = join(fakeBin, "peb");
+  writeFileSync(
+    peb,
+    `#!/usr/bin/env bash
+if [[ "$1" == "list" ]]; then
+  printf '%s\n' '{"data":[{"id":"dotfiles-aaa"},{"id":"dotfiles-bbb"}]}'
+  exit 0
+fi
+if [[ "$1" == "show" ]]; then
+  case "$2" in
+    dotfiles-aaa) printf '%s\n' '{"data":{"title":"First","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-bbb) printf '%s\n' '{"data":{"title":"Second","status":"ready_for_agent"}}'; exit 0 ;;
+  esac
+fi
+if [[ "$1" == "update" ]]; then
+  printf '%s\n' 'ok'
+  exit 0
+fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(peb, 0o755);
+
+  const agentLog = join(tempRoot, "agent.log");
+  const agentLock = join(tempRoot, "agent.lock");
+  const agentCommand = `
+issue="\${PICASTLE_AGENT_NAME#implementer-}"
+printf 'start %s\n' "$issue" >> ${JSON.stringify(agentLog)}
+if [[ -e ${JSON.stringify(agentLock)} ]]; then
+  printf 'concurrent %s\n' "$issue" >> ${JSON.stringify(agentLog)}
+  exit 9
+fi
+touch ${JSON.stringify(agentLock)}
+sleep 0.2
+git add .
+git -c user.name='Picastle Test' -c user.email=test@example.com commit -m "$issue recovery\n\nCloses: $issue"
+rm -f ${JSON.stringify(agentLock)}
+printf 'end %s\n' "$issue" >> ${JSON.stringify(agentLog)}
+`;
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1", "--concurrency", "2", "--no-pr", "--no-push", "--no-verify"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      XDG_CACHE_HOME: xdgCache,
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_PUBLISHER_AGENT: "0",
+      PICASTLE_STACK_PRS: "1",
+      PICASTLE_TEST_AGENT_COMMAND: agentCommand,
+    },
+  });
+
+  assert.match(output, /Recovery contains stacked implementation work; resuming sequentially in stack order\./);
+  assert.match(output, /rebasing stack branch picastle\/dotfiles-bbb-second onto picastle\/dotfiles-aaa-first/);
+  assert.equal(readFileSync(agentLog, "utf8"), "start dotfiles-aaa\nend dotfiles-aaa\nstart dotfiles-bbb\nend dotfiles-bbb\n");
+  assert.doesNotThrow(() => execFileSync("git", ["merge-base", "--is-ancestor", firstBranch, secondBranch], { cwd: repo }));
+});
+
 function hashStringForTest(input: string): string {
   let hash = 5381;
   for (const char of input) hash = ((hash << 5) + hash + char.charCodeAt(0)) >>> 0;

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -1545,15 +1545,21 @@ if [[ "$1 $2" == "pr list" ]]; then
 fi
 if [[ "$1 $2" == "pr create" ]]; then
   args=" $* "
+  body_file=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in --body-file) body_file="$2"; shift 2 ;; *) shift ;; esac
+  done
   if [[ "$args" == *" --base main "* && "$args" == *" --head picastle/dotfiles-aaa-first "* ]]; then
     printf '%s\n' 'https://github.com/acme/repo/pull/1'
     exit 0
   fi
   if [[ "$args" == *" --base picastle/dotfiles-aaa-first "* && "$args" == *" --head picastle/dotfiles-bbb-second "* ]]; then
+    grep -q 'previousHeadSha' "$body_file" || { echo "missing second stack previousHeadSha" >&2; exit 3; }
     printf '%s\n' 'https://github.com/acme/repo/pull/2'
     exit 0
   fi
   if [[ "$args" == *" --base picastle/dotfiles-bbb-second "* && "$args" == *" --head picastle/dotfiles-ccc-third "* ]]; then
+    grep -q 'previousHeadSha' "$body_file" || { echo "missing third stack previousHeadSha" >&2; exit 3; }
     printf '%s\n' 'https://github.com/acme/repo/pull/3'
     exit 0
   fi
@@ -2780,6 +2786,109 @@ exit 1
   assert.equal(execFileSync("git", ["rev-parse", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }), execFileSync("git", ["rev-parse", "origin/picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }));
   assert.match(readFileSync(ghLog, "utf8"), /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
   assert.match(readFileSync(pebLog, "utf8"), /comment add dotfiles-bbb Picastle published stacked PR 2\/2/);
+});
+
+test("stack reconciliation rebases downstream with old upstream boundary after multi-commit squash merge", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-squash-boundary-"));
+  const repo = join(tempRoot, "repo");
+  const origin = join(tempRoot, "origin.git");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--bare", origin], { encoding: "utf8" });
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "Picastle Test"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a1.txt"), "upstream one\n");
+  execFileSync("git", ["add", "a1.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-aaa part one"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a2.txt"), "upstream two\n");
+  execFileSync("git", ["add", "a2.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-aaa part two"], { cwd: repo, encoding: "utf8" });
+  const upstreamTip = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim();
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "downstream only\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-bbb"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a1.txt"), "upstream one\n");
+  writeFileSync(join(repo, "a2.txt"), "upstream two\n");
+  execFileSync("git", ["add", "a1.txt", "a2.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "squash upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+
+  const stackBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId: "dotfiles-aaa-dotfiles-bbb",
+    index: 2,
+    total: 2,
+    issueId: "dotfiles-bbb",
+    headBranch: "picastle/dotfiles-bbb-downstream",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-aaa-upstream",
+    previousHeadSha: upstreamTip,
+  })}\n-->`;
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+  const gh = join(fakeBin, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then cat <<'JSON'
+[{"number":22,"headRefName":"picastle/dotfiles-bbb-downstream","baseRefName":"picastle/dotfiles-aaa-upstream","url":"https://github.com/acme/repo/pull/22","body":${JSON.stringify(stackBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]
+JSON
+exit 0; fi
+if [[ "$1 $2" == "pr edit" ]]; then exit 0; fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+  const peb = join(fakeBin, "peb");
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb"}]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Downstream","status":"ready_for_agent"}}'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then printf '%s\n' 'ok'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_MAX_ISSUES: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /rebasing stack branch picastle\/dotfiles-bbb-downstream onto main/);
+  assert.match(readFileSync(ghLog, "utf8"), /pr edit https:\/\/github\.com\/acme\/repo\/pull\/22 --base main/);
+  assert.deepEqual(
+    execFileSync("git", ["diff", "--name-only", "main...picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }).trim().split("\n").filter(Boolean),
+    ["b.txt"],
+  );
+  assert.equal(execFileSync("git", ["rev-parse", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }), execFileSync("git", ["rev-parse", "origin/picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" }));
 });
 
 test("interrupted dirty stack recovery resumes sequentially before downstream rebase", () => {

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -2460,6 +2460,121 @@ exit 1
   assert.doesNotMatch(readFileSync(ghLog, "utf8"), /pr edit/);
 });
 
+test("dirty recovered stack PR cascades rebase to clean open downstream PRs", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-dirty-stack-cascade-"));
+  const repo = join(tempRoot, "repo");
+  const origin = join(tempRoot, "origin.git");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--bare", origin], { encoding: "utf8" });
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "Picastle Test"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-aaa"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "middle\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-bbb"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "c.txt"), "tail\n");
+  execFileSync("git", ["add", "c.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "dotfiles-ccc"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["push", "-u", "origin", "picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["commit", "-m", "squash upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "picastle/dotfiles-bbb-middle"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "dirty.txt"), "resumed middle repair\n");
+
+  const stackId = "dotfiles-aaa-dotfiles-bbb-dotfiles-ccc";
+  const middleBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId,
+    index: 2,
+    total: 3,
+    issueId: "dotfiles-bbb",
+    headBranch: "picastle/dotfiles-bbb-middle",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-aaa-upstream",
+    nextBranch: "picastle/dotfiles-ccc-tail",
+  })}\n-->`;
+  const tailBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId,
+    index: 3,
+    total: 3,
+    issueId: "dotfiles-ccc",
+    headBranch: "picastle/dotfiles-ccc-tail",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-bbb-middle",
+  })}\n-->`;
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+  const gh = join(fakeBin, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then cat <<'JSON'
+[{"number":22,"headRefName":"picastle/dotfiles-bbb-middle","baseRefName":"picastle/dotfiles-aaa-upstream","url":"https://github.com/acme/repo/pull/22","body":${JSON.stringify(middleBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}},{"number":33,"headRefName":"picastle/dotfiles-ccc-tail","baseRefName":"picastle/dotfiles-bbb-middle","url":"https://github.com/acme/repo/pull/33","body":${JSON.stringify(tailBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]
+JSON
+exit 0; fi
+if [[ "$1 $2" == "pr edit" ]]; then exit 0; fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+  const peb = join(fakeBin, "peb");
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb"},{"id":"dotfiles-ccc"}]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Stack entry","status":"ready_for_agent"}}'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then printf '%s\n' 'ok'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const result = spawnSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1", "--no-verify"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_PUBLISHER_AGENT: "0",
+      PICASTLE_STACK_PRS: "1",
+      PICASTLE_TEST_AGENT_COMMAND: "git add dirty.txt && git commit -m 'dotfiles-bbb recovery\n\nCloses: dotfiles-bbb'",
+    },
+  });
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 0, output);
+  assert.match(output, /stack reconcile deferred: picastle\/dotfiles-bbb-middle base main \(dirty worktree; recovery will resume it first\)/);
+  assert.match(output, /updated existing PR on picastle\/dotfiles-bbb-middle: https:\/\/github\.com\/acme\/repo\/pull\/22/);
+  assert.match(output, /rebasing stack branch picastle\/dotfiles-ccc-tail onto picastle\/dotfiles-bbb-middle/);
+  assert.doesNotThrow(() => execFileSync("git", ["merge-base", "--is-ancestor", "picastle/dotfiles-bbb-middle", "picastle/dotfiles-ccc-tail"], { cwd: repo }));
+  assert.equal(execFileSync("git", ["rev-parse", "picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" }), execFileSync("git", ["rev-parse", "origin/picastle/dotfiles-ccc-tail"], { cwd: repo, encoding: "utf8" }));
+});
+
 test("stack reconciliation rebases later downstream PRs after predecessor is rewritten", () => {
   const packageDir = dirname(fileURLToPath(import.meta.url));
   const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-cascade-rebase-"));

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -1764,6 +1764,150 @@ exit 1
   assert.match(ghTrace, /pr create --base picastle\/dotfiles-aaa-second --head picastle\/dotfiles-mmm-third/);
 });
 
+test("partial stack recovery preserves already-open predecessor bases", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stacked-partial-recovery-"));
+  const repo = join(tempRoot, "repo");
+  const origin = join(tempRoot, "origin.git");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--bare", origin], { encoding: "utf8" });
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], {
+    cwd: repo,
+    encoding: "utf8",
+  });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repo, encoding: "utf8" });
+
+  const branches = [
+    ["picastle/dotfiles-aaa-first", "a.txt", "dotfiles-aaa"],
+    ["picastle/dotfiles-bbb-second", "b.txt", "dotfiles-bbb"],
+    ["picastle/dotfiles-ccc-third", "c.txt", "dotfiles-ccc"],
+  ] as const;
+  for (const [index, [branch, file, issueId]] of branches.entries()) {
+    execFileSync("git", ["checkout", "-b", branch], { cwd: repo, encoding: "utf8" });
+    writeFileSync(join(repo, file), `${issueId}\n`);
+    execFileSync("git", ["add", file], { cwd: repo, encoding: "utf8" });
+    execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", `${issueId}\n\nCloses: ${issueId}`], {
+      cwd: repo,
+      encoding: "utf8",
+    });
+    if (index === 0) execFileSync("git", ["push", "-u", "origin", branch], { cwd: repo, encoding: "utf8" });
+  }
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+
+  const xdgCache = join(tempRoot, "cache");
+  const stackDir = join(xdgCache, "picastle", safeRepoIdForTest(realpathSync(repo)), "stacks");
+  mkdirSync(stackDir, { recursive: true });
+  const stackId = "dotfiles-aaa-dotfiles-bbb-dotfiles-ccc";
+  const metadata = branches.map(([branch, , issueId], index) => ({
+    stackId,
+    index: index + 1,
+    total: branches.length,
+    issueId,
+    headBranch: branch,
+    baseBranch: "main",
+    ...(index > 0 ? { previousBranch: branches[index - 1]![0] } : {}),
+    ...(index < branches.length - 1 ? { nextBranch: branches[index + 1]![0] } : {}),
+  }));
+  for (const stack of metadata) {
+    writeFileSync(join(stackDir, `${hashStringForTest(stack.headBranch)}.json`), JSON.stringify(stack));
+  }
+
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+
+  const firstPrBody = `<!-- picastle-stack\n${JSON.stringify(metadata[0])}\n-->`;
+  const gh = join(fakeBin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then
+  printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'
+  exit 0
+fi
+if [[ "$1 $2" == "pr list" ]]; then
+  printf '%s\n' '[{"number":10,"headRefName":"picastle/dotfiles-aaa-first","baseRefName":"main","url":"https://github.com/acme/repo/pull/10","body":${JSON.stringify(firstPrBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]'
+  exit 0
+fi
+if [[ "$1 $2" == "pr create" ]]; then
+  args=" $* "
+  if [[ "$args" == *" --base picastle/dotfiles-aaa-first "* && "$args" == *" --head picastle/dotfiles-bbb-second "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/11'
+    exit 0
+  fi
+  if [[ "$args" == *" --base picastle/dotfiles-bbb-second "* && "$args" == *" --head picastle/dotfiles-ccc-third "* ]]; then
+    printf '%s\n' 'https://github.com/acme/repo/pull/12'
+    exit 0
+  fi
+  echo "unexpected partial stacked gh pr create invocation: $*" >&2
+  exit 2
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(gh, 0o755);
+
+  const peb = join(fakeBin, "peb");
+  writeFileSync(
+    peb,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then
+  printf '%s\n' '{"data":[{"id":"dotfiles-aaa"},{"id":"dotfiles-bbb"},{"id":"dotfiles-ccc"}]}'
+  exit 0
+fi
+if [[ "$1" == "show" ]]; then
+  case "$2" in
+    dotfiles-aaa) printf '%s\n' '{"data":{"title":"First","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-bbb) printf '%s\n' '{"data":{"title":"Second","status":"ready_for_agent"}}'; exit 0 ;;
+    dotfiles-ccc) printf '%s\n' '{"data":{"title":"Third","status":"ready_for_agent"}}'; exit 0 ;;
+  esac
+fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then
+  printf '%s\n' 'ok'
+  exit 0
+fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: xdgCache,
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_PUBLISHER_AGENT: "0",
+      PICASTLE_PUSH: "0",
+      PICASTLE_VERIFY: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /Recovery has unpublished local branches/);
+  const ghTrace = readFileSync(ghLog, "utf8");
+  assert.doesNotMatch(ghTrace, /pr create --base main --head picastle\/dotfiles-bbb-second/);
+  assert.match(ghTrace, /pr create --base picastle\/dotfiles-aaa-first --head picastle\/dotfiles-bbb-second/);
+  assert.match(ghTrace, /pr create --base picastle\/dotfiles-bbb-second --head picastle\/dotfiles-ccc-third/);
+});
+
 test("stack reconciliation rebases downstream branches before retargeting merged upstream PRs", () => {
   const packageDir = dirname(fileURLToPath(import.meta.url));
   const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-rebase-"));

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -1847,6 +1847,9 @@ if [[ "$1 $2" == "pr create" ]]; then
   echo "empty downstream branch should not be published" >&2
   exit 2
 fi
+if [[ "$1 $2" == "pr edit" ]]; then
+  exit 0
+fi
 echo "unexpected gh invocation: $*" >&2
 exit 1
 `,
@@ -2131,6 +2134,9 @@ if [[ "$1 $2" == "pr create" ]]; then
   fi
   echo "unexpected partial stacked gh pr create invocation: $*" >&2
   exit 2
+fi
+if [[ "$1 $2" == "pr edit" ]]; then
+  exit 0
 fi
 echo "unexpected gh invocation: $*" >&2
 exit 1

--- a/pi/picastle/recovery.test.mts
+++ b/pi/picastle/recovery.test.mts
@@ -1908,6 +1908,193 @@ exit 1
   assert.match(ghTrace, /pr create --base picastle\/dotfiles-bbb-second --head picastle\/dotfiles-ccc-third/);
 });
 
+test("unpublished stack recovery clears merged upstream predecessors before creating PR", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stacked-merged-upstream-"));
+  const repo = join(tempRoot, "repo");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "dotfiles-aaa\n\nCloses: dotfiles-aaa"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "downstream\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "dotfiles-bbb\n\nCloses: dotfiles-bbb"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "squash upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+
+  const xdgCache = join(tempRoot, "cache");
+  const stackDir = join(xdgCache, "picastle", safeRepoIdForTest(realpathSync(repo)), "stacks");
+  mkdirSync(stackDir, { recursive: true });
+  const staleStack = {
+    stackId: "dotfiles-aaa-dotfiles-bbb",
+    index: 2,
+    total: 2,
+    issueId: "dotfiles-bbb",
+    headBranch: "picastle/dotfiles-bbb-downstream",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-aaa-upstream",
+  };
+  writeFileSync(join(stackDir, `${hashStringForTest(staleStack.headBranch)}.json`), JSON.stringify(staleStack));
+
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+  const gh = join(fakeBin, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then printf '%s\n' '[]'; exit 0; fi
+if [[ "$1 $2" == "pr create" ]]; then
+  args=" $* "
+  body_file=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in --body-file) body_file="$2"; shift 2 ;; *) shift ;; esac
+  done
+  if [[ "$args" == *" --base main "* && "$args" == *" --head picastle/dotfiles-bbb-downstream "* ]]; then
+    if grep -q 'Previous:' "$body_file"; then echo "stale stack previous branch in PR body" >&2; exit 3; fi
+    printf '%s\n' 'https://github.com/acme/repo/pull/20'
+    exit 0
+  fi
+  echo "unexpected recovered downstream gh pr create invocation: $args" >&2
+  exit 2
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+
+  const peb = join(fakeBin, "peb");
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb"}]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Downstream","status":"ready_for_agent"}}'; exit 0; fi
+if [[ "$1 $2" == "closes add" || "$1" == "update" || "$1 $2" == "comment add" ]]; then printf '%s\n' 'ok'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: xdgCache,
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_PUBLISHER_AGENT: "0",
+      PICASTLE_PUSH: "0",
+      PICASTLE_VERIFY: "0",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /stack metadata refresh: picastle\/dotfiles-bbb-downstream base main/);
+  assert.match(output, /rebasing stack branch picastle\/dotfiles-bbb-downstream onto main/);
+  assert.match(readFileSync(ghLog, "utf8"), /pr create --base main --head picastle\/dotfiles-bbb-downstream/);
+  assert.doesNotThrow(() => execFileSync("git", ["merge-base", "--is-ancestor", "main", "picastle/dotfiles-bbb-downstream"], { cwd: repo }));
+});
+
+test("plan-only recovery spots dirty open downstream stack PRs after merged upstream", () => {
+  const packageDir = dirname(fileURLToPath(import.meta.url));
+  const tempRoot = mkdtempSync(join(tmpdir(), "picastle-dirty-open-stack-"));
+  const repo = join(tempRoot, "repo");
+  const fakeBin = join(tempRoot, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  execFileSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf8" });
+  writeFileSync(join(repo, "README.md"), "# test repo\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "initial"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "dotfiles-aaa"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "-b", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "b.txt"), "downstream\n");
+  execFileSync("git", ["add", "b.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "dotfiles-bbb"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "main"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "a.txt"), "upstream\n");
+  execFileSync("git", ["add", "a.txt"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["-c", "user.name=Picastle Test", "-c", "user.email=test@example.com", "commit", "-m", "squash upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["branch", "-D", "picastle/dotfiles-aaa-upstream"], { cwd: repo, encoding: "utf8" });
+  execFileSync("git", ["checkout", "picastle/dotfiles-bbb-downstream"], { cwd: repo, encoding: "utf8" });
+  writeFileSync(join(repo, "dirty.txt"), "uncommitted downstream repair\n");
+
+  const stackBody = `<!-- picastle-stack\n${JSON.stringify({
+    stackId: "dotfiles-aaa-dotfiles-bbb",
+    index: 2,
+    total: 2,
+    issueId: "dotfiles-bbb",
+    headBranch: "picastle/dotfiles-bbb-downstream",
+    baseBranch: "main",
+    previousBranch: "picastle/dotfiles-aaa-upstream",
+  })}\n-->`;
+  const ghLog = join(tempRoot, "gh.log");
+  const pebLog = join(tempRoot, "peb.log");
+  const bash = join(fakeBin, "bash");
+  writeFileSync(bash, "#!/bin/sh\nexec /bin/bash --noprofile --norc \"$@\"\n");
+  chmodSync(bash, 0o755);
+  const gh = join(fakeBin, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1 $2" == "repo view" ]]; then printf '%s\n' '{"name":"repo","owner":{"login":"acme"}}'; exit 0; fi
+if [[ "$1 $2" == "pr list" ]]; then cat <<'JSON'
+[{"number":22,"headRefName":"picastle/dotfiles-bbb-downstream","baseRefName":"picastle/dotfiles-aaa-upstream","url":"https://github.com/acme/repo/pull/22","body":${JSON.stringify(stackBody)},"isCrossRepository":false,"headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"acme"}}]
+JSON
+exit 0; fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`);
+  chmodSync(gh, 0o755);
+  const peb = join(fakeBin, "peb");
+  writeFileSync(peb, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PEB_LOG"
+if [[ "$1" == "list" ]]; then printf '%s\n' '{"data":[{"id":"dotfiles-bbb","title":"Downstream","status":"ready_for_agent"}]}'; exit 0; fi
+if [[ "$1" == "show" ]]; then printf '%s\n' '{"data":{"title":"Downstream","status":"ready_for_agent"}}'; exit 0; fi
+echo "unexpected peb invocation: $*" >&2
+exit 1
+`);
+  chmodSync(peb, 0o755);
+
+  const output = execFileSync(join(packageDir, "node_modules", ".bin", "tsx"), ["main.mts", "--repo", repo, "--max-iterations", "1", "--plan-only"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GH_LOG: ghLog,
+      PEB_LOG: pebLog,
+      XDG_CACHE_HOME: join(tempRoot, "cache"),
+      PICASTLE_PEB_REMOTE: "",
+      PICASTLE_PEB_REPO: "",
+      PICASTLE_STACK_PRS: "1",
+    },
+  });
+
+  assert.match(output, /Recovery scan: 1 interrupted/);
+  assert.match(output, /stack retarget: picastle\/dotfiles-bbb-downstream base picastle\/dotfiles-aaa-upstream → main \(plan-only\)/);
+  assert.doesNotMatch(readFileSync(ghLog, "utf8"), /pr edit/);
+});
+
 test("stack reconciliation rebases downstream branches before retargeting merged upstream PRs", () => {
   const packageDir = dirname(fileURLToPath(import.meta.url));
   const tempRoot = mkdtempSync(join(tmpdir(), "picastle-stack-rebase-"));

--- a/pi/picastle/stack.mts
+++ b/pi/picastle/stack.mts
@@ -30,6 +30,7 @@ export type StackRetargetAction = {
   currentBody?: string;
   updateBase: boolean;
   updateBody: boolean;
+  effectiveBaseChanged: boolean;
 };
 
 const STACK_MARKER_START = "<!-- picastle-stack";
@@ -143,6 +144,7 @@ export function planStackRetargets(openPrs: StackPrRecord[], baseBranch: string)
         nextBranch: entry.stack.nextBranch,
       });
       const expectedBase = stackBaseBranch(refreshedStack);
+      const effectiveBaseChanged = stackBaseBranch(entry.stack) !== expectedBase;
       const updateBase = Boolean(entry.pr.baseRefName && entry.pr.baseRefName !== expectedBase);
       const updateBody = !stackMetadataEqual(entry.stack, refreshedStack);
       if (updateBase || updateBody) {
@@ -155,6 +157,7 @@ export function planStackRetargets(openPrs: StackPrRecord[], baseBranch: string)
           currentBody: entry.pr.body,
           updateBase,
           updateBody,
+          effectiveBaseChanged,
         });
       }
     }

--- a/pi/picastle/stack.mts
+++ b/pi/picastle/stack.mts
@@ -1,0 +1,183 @@
+import type { PlannedIssue } from "./planner-output.mjs";
+
+export type StackMetadata = {
+  stackId: string;
+  index: number;
+  total: number;
+  issueId: string;
+  headBranch: string;
+  baseBranch: string;
+  previousBranch?: string;
+  nextBranch?: string;
+};
+
+export type StackedIssue<T extends PlannedIssue = PlannedIssue> = T & { stack: StackMetadata };
+
+export type StackPrRecord = {
+  number?: number | string;
+  headRefName: string;
+  baseRefName?: string;
+  url?: string;
+  body?: string;
+};
+
+export type StackRetargetAction = {
+  prRef: string;
+  headRefName: string;
+  currentBase?: string;
+  expectedBase: string;
+  stack: StackMetadata;
+};
+
+const STACK_MARKER_START = "<!-- picastle-stack";
+const STACK_MARKER_END = "-->";
+
+export function stackIssues<T extends PlannedIssue>(issues: T[], baseBranch: string): Array<StackedIssue<T>> {
+  const stackId = defaultStackId(issues);
+  return issues.map((issue, index) => ({
+    ...issue,
+    stack: {
+      stackId,
+      index: index + 1,
+      total: issues.length,
+      issueId: issue.id,
+      headBranch: issue.branch,
+      baseBranch,
+      ...(index > 0 ? { previousBranch: issues[index - 1]!.branch } : {}),
+      ...(index < issues.length - 1 ? { nextBranch: issues[index + 1]!.branch } : {}),
+    },
+  }));
+}
+
+export function stackBaseBranch(stack: StackMetadata): string {
+  return stack.previousBranch ?? stack.baseBranch;
+}
+
+export function stackContext(stack: StackMetadata | undefined): string {
+  if (!stack) return "Stacked PR mode: disabled for this issue.";
+  const base = stackBaseBranch(stack);
+  const lines = [
+    `Stacked PR mode: this is position ${stack.index}/${stack.total} in stack ${stack.stackId}.`,
+    `This branch should target base branch \`${base}\`.`,
+  ];
+  if (stack.previousBranch) lines.push(`Previous stack branch: \`${stack.previousBranch}\`.`);
+  if (stack.nextBranch) lines.push(`Next stack branch: \`${stack.nextBranch}\`.`);
+  lines.push("Keep commits scoped to the current issue; do not rewrite earlier stack entries unless explicitly repairing stack integration.");
+  return lines.join("\n");
+}
+
+export function stackPrBodySection(stack: StackMetadata | undefined): string {
+  if (!stack) return "";
+  const marker = `${STACK_MARKER_START}\n${JSON.stringify(stack)}\n${STACK_MARKER_END}`;
+  const lines = [
+    marker,
+    "",
+    "## Stack",
+    "",
+    `This PR is **${stack.index} of ${stack.total}** in Picastle stack \`${stack.stackId}\`.`,
+    `Base: \`${stackBaseBranch(stack)}\``,
+  ];
+  if (stack.previousBranch) lines.push(`Previous: \`${stack.previousBranch}\``);
+  if (stack.nextBranch) lines.push(`Next: \`${stack.nextBranch}\``);
+  return `${lines.join("\n")}\n`;
+}
+
+export function stackPebblesComment(stack: StackMetadata | undefined, prRef: string): string | undefined {
+  if (!stack) return undefined;
+  const lines = [
+    `Picastle published stacked PR ${stack.index}/${stack.total}: ${prRef}`,
+    `Stack: ${stack.stackId}`,
+    `Branch: ${stack.headBranch}`,
+    `Base: ${stackBaseBranch(stack)}`,
+  ];
+  if (stack.previousBranch) lines.push(`Previous stack branch: ${stack.previousBranch}`);
+  if (stack.nextBranch) lines.push(`Next stack branch: ${stack.nextBranch}`);
+  return lines.join("\n");
+}
+
+export function parseStackMetadataFromBody(body: string | undefined): StackMetadata | undefined {
+  if (!body) return undefined;
+  const start = body.indexOf(STACK_MARKER_START);
+  if (start < 0) return undefined;
+  const jsonStart = body.indexOf("\n", start);
+  if (jsonStart < 0) return undefined;
+  const end = body.indexOf(STACK_MARKER_END, jsonStart + 1);
+  if (end < 0) return undefined;
+  const raw = body.slice(jsonStart + 1, end).trim();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  return normalizeStackMetadata(parsed);
+}
+
+export function planStackRetargets(openPrs: StackPrRecord[], baseBranch: string): StackRetargetAction[] {
+  const entries = openPrs
+    .map((pr) => ({ pr, stack: parseStackMetadataFromBody(pr.body) }))
+    .filter((entry): entry is { pr: StackPrRecord; stack: StackMetadata } => Boolean(entry.stack));
+
+  const byStackId = new Map<string, Array<{ pr: StackPrRecord; stack: StackMetadata }>>();
+  for (const entry of entries) {
+    const group = byStackId.get(entry.stack.stackId) ?? [];
+    group.push(entry);
+    byStackId.set(entry.stack.stackId, group);
+  }
+
+  const actions: StackRetargetAction[] = [];
+  for (const group of byStackId.values()) {
+    group.sort((a, b) => a.stack.index - b.stack.index || a.pr.headRefName.localeCompare(b.pr.headRefName));
+    let previousOpenHead: string | undefined;
+    for (const entry of group) {
+      const expectedBase = previousOpenHead ?? baseBranch;
+      if (entry.pr.baseRefName && entry.pr.baseRefName !== expectedBase) {
+        actions.push({
+          prRef: entry.pr.url || (entry.pr.number ? String(entry.pr.number) : entry.pr.headRefName),
+          headRefName: entry.pr.headRefName,
+          currentBase: entry.pr.baseRefName,
+          expectedBase,
+          stack: entry.stack,
+        });
+      }
+      previousOpenHead = entry.pr.headRefName;
+    }
+  }
+
+  return actions;
+}
+
+function defaultStackId(issues: PlannedIssue[]): string {
+  const ids = issues.map((issue) => issue.id).join("-");
+  return ids.length <= 80 ? ids : `${issues[0]?.id ?? "stack"}-${issues.at(-1)?.id ?? "tail"}-${issues.length}`;
+}
+
+function normalizeStackMetadata(value: unknown): StackMetadata | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const stackId = stringField(record.stackId);
+  const issueId = stringField(record.issueId);
+  const headBranch = stringField(record.headBranch);
+  const baseBranch = stringField(record.baseBranch);
+  const index = numberField(record.index);
+  const total = numberField(record.total);
+  if (!stackId || !issueId || !headBranch || !baseBranch || !index || !total) return undefined;
+  return {
+    stackId,
+    index,
+    total,
+    issueId,
+    headBranch,
+    baseBranch,
+    ...(stringField(record.previousBranch) ? { previousBranch: stringField(record.previousBranch) } : {}),
+    ...(stringField(record.nextBranch) ? { nextBranch: stringField(record.nextBranch) } : {}),
+  };
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}

--- a/pi/picastle/stack.mts
+++ b/pi/picastle/stack.mts
@@ -142,7 +142,7 @@ export function planStackRetargets(openPrs: StackPrRecord[], baseBranch: string)
         baseBranch,
         headBranch: entry.pr.headRefName,
         previousBranch: group[index - 1]?.pr.headRefName,
-        nextBranch: entry.stack.nextBranch,
+        nextBranch: group[index + 1]?.pr.headRefName,
       });
       const expectedBase = stackBaseBranch(refreshedStack);
       const effectiveBaseChanged = stackBaseBranch(entry.stack) !== expectedBase;

--- a/pi/picastle/stack.mts
+++ b/pi/picastle/stack.mts
@@ -27,6 +27,9 @@ export type StackRetargetAction = {
   currentBase?: string;
   expectedBase: string;
   stack: StackMetadata;
+  currentBody?: string;
+  updateBase: boolean;
+  updateBody: boolean;
 };
 
 const STACK_MARKER_START = "<!-- picastle-stack";
@@ -132,23 +135,73 @@ export function planStackRetargets(openPrs: StackPrRecord[], baseBranch: string)
   const actions: StackRetargetAction[] = [];
   for (const group of byStackId.values()) {
     group.sort((a, b) => a.stack.index - b.stack.index || a.pr.headRefName.localeCompare(b.pr.headRefName));
-    let previousOpenHead: string | undefined;
-    for (const entry of group) {
-      const expectedBase = previousOpenHead ?? baseBranch;
-      if (entry.pr.baseRefName && entry.pr.baseRefName !== expectedBase) {
+    for (const [index, entry] of group.entries()) {
+      const refreshedStack = relinkStackMetadata(entry.stack, {
+        baseBranch,
+        headBranch: entry.pr.headRefName,
+        previousBranch: group[index - 1]?.pr.headRefName,
+        nextBranch: entry.stack.nextBranch,
+      });
+      const expectedBase = stackBaseBranch(refreshedStack);
+      const updateBase = Boolean(entry.pr.baseRefName && entry.pr.baseRefName !== expectedBase);
+      const updateBody = !stackMetadataEqual(entry.stack, refreshedStack);
+      if (updateBase || updateBody) {
         actions.push({
           prRef: entry.pr.url || (entry.pr.number ? String(entry.pr.number) : entry.pr.headRefName),
           headRefName: entry.pr.headRefName,
           currentBase: entry.pr.baseRefName,
           expectedBase,
-          stack: entry.stack,
+          stack: refreshedStack,
+          currentBody: entry.pr.body,
+          updateBase,
+          updateBody,
         });
       }
-      previousOpenHead = entry.pr.headRefName;
     }
   }
 
   return actions;
+}
+
+export function upsertStackPrBodySection(body: string | undefined, stack: StackMetadata): string {
+  const section = stackPrBodySection(stack).trimEnd();
+  if (!body) return `${section}\n`;
+  const start = body.indexOf(STACK_MARKER_START);
+  if (start < 0) return `${section}\n\n${body}`;
+
+  const markerEnd = body.indexOf(STACK_MARKER_END, start);
+  if (markerEnd < 0) return `${section}\n\n${body}`;
+  const afterMarker = markerEnd + STACK_MARKER_END.length;
+  const nextHeading = body.slice(afterMarker).match(/\n## (?!Stack\b)/);
+  const end = nextHeading?.index === undefined ? body.length : afterMarker + nextHeading.index;
+  return `${body.slice(0, start)}${section}${body.slice(end)}`;
+}
+
+export function relinkStackMetadata(
+  stack: StackMetadata,
+  links: { baseBranch: string; headBranch?: string; previousBranch?: string; nextBranch?: string },
+): StackMetadata {
+  const relinked: StackMetadata = {
+    ...stack,
+    headBranch: links.headBranch ?? stack.headBranch,
+    baseBranch: links.baseBranch,
+  };
+  if (links.previousBranch) relinked.previousBranch = links.previousBranch;
+  else delete relinked.previousBranch;
+  if (links.nextBranch) relinked.nextBranch = links.nextBranch;
+  else delete relinked.nextBranch;
+  return relinked;
+}
+
+export function stackMetadataEqual(a: StackMetadata, b: StackMetadata): boolean {
+  return a.stackId === b.stackId &&
+    a.index === b.index &&
+    a.total === b.total &&
+    a.issueId === b.issueId &&
+    a.headBranch === b.headBranch &&
+    a.baseBranch === b.baseBranch &&
+    a.previousBranch === b.previousBranch &&
+    a.nextBranch === b.nextBranch;
 }
 
 function defaultStackId(issues: PlannedIssue[]): string {

--- a/pi/picastle/stack.mts
+++ b/pi/picastle/stack.mts
@@ -8,6 +8,7 @@ export type StackMetadata = {
   headBranch: string;
   baseBranch: string;
   previousBranch?: string;
+  previousHeadSha?: string;
   nextBranch?: string;
 };
 
@@ -204,6 +205,7 @@ export function stackMetadataEqual(a: StackMetadata, b: StackMetadata): boolean 
     a.headBranch === b.headBranch &&
     a.baseBranch === b.baseBranch &&
     a.previousBranch === b.previousBranch &&
+    a.previousHeadSha === b.previousHeadSha &&
     a.nextBranch === b.nextBranch;
 }
 
@@ -230,6 +232,7 @@ function normalizeStackMetadata(value: unknown): StackMetadata | undefined {
     headBranch,
     baseBranch,
     ...(stringField(record.previousBranch) ? { previousBranch: stringField(record.previousBranch) } : {}),
+    ...(shaField(record.previousHeadSha) ? { previousHeadSha: shaField(record.previousHeadSha) } : {}),
     ...(stringField(record.nextBranch) ? { nextBranch: stringField(record.nextBranch) } : {}),
   };
 }
@@ -240,4 +243,8 @@ function stringField(value: unknown): string | undefined {
 
 function numberField(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function shaField(value: unknown): string | undefined {
+  return typeof value === "string" && /^[0-9a-f]{7,40}$/i.test(value) ? value : undefined;
 }

--- a/pi/picastle/stack.mts
+++ b/pi/picastle/stack.mts
@@ -95,6 +95,10 @@ export function stackPebblesComment(stack: StackMetadata | undefined, prRef: str
   return lines.join("\n");
 }
 
+export function parseStackMetadataJson(value: unknown): StackMetadata | undefined {
+  return normalizeStackMetadata(value);
+}
+
 export function parseStackMetadataFromBody(body: string | undefined): StackMetadata | undefined {
   if (!body) return undefined;
   const start = body.indexOf(STACK_MARKER_START);

--- a/pi/picastle/stack.test.mts
+++ b/pi/picastle/stack.test.mts
@@ -5,6 +5,7 @@ import {
   parseStackMetadataFromBody,
   planStackRetargets,
   stackBaseBranch,
+  upsertStackPrBodySection,
   stackContext,
   stackIssues,
   stackPebblesComment,
@@ -90,4 +91,47 @@ test("ignores malformed or non-stack PR bodies when planning retargets", () => {
     ),
     [],
   );
+});
+
+test("refreshes stack body metadata when an upstream stack PR is gone", () => {
+  const [first, second, third] = stackIssues(
+    [
+      { id: "repo-aaa", title: "A", branch: "picastle/repo-aaa-a" },
+      { id: "repo-bbb", title: "B", branch: "picastle/repo-bbb-b" },
+      { id: "repo-ccc", title: "C", branch: "picastle/repo-ccc-c" },
+    ],
+    "main",
+  );
+
+  const actions = planStackRetargets(
+    [
+      {
+        number: 2,
+        headRefName: second!.branch,
+        baseRefName: first!.branch,
+        url: "https://github.com/acme/repo/pull/2",
+        body: stackPrBodySection(second!.stack),
+      },
+      {
+        number: 3,
+        headRefName: third!.branch,
+        baseRefName: third!.stack.previousBranch,
+        url: "https://github.com/acme/repo/pull/3",
+        body: stackPrBodySection(third!.stack),
+      },
+    ],
+    "main",
+  );
+
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0]!.expectedBase, "main");
+  assert.equal(actions[0]!.stack.previousBranch, undefined);
+  assert.equal(actions[0]!.stack.nextBranch, third!.branch);
+  assert.equal(actions[0]!.updateBody, true);
+
+  const originalBody = `${stackPrBodySection(second!.stack)}## Summary\n\nKeep this text.\n`;
+  const refreshedBody = upsertStackPrBodySection(originalBody, actions[0]!.stack);
+  assert.match(refreshedBody, /Base: `main`/);
+  assert.doesNotMatch(refreshedBody, /Previous: `picastle\/repo-aaa-a`/);
+  assert.match(refreshedBody, /## Summary\n\nKeep this text/);
 });

--- a/pi/picastle/stack.test.mts
+++ b/pi/picastle/stack.test.mts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseStackMetadataFromBody,
+  planStackRetargets,
+  stackBaseBranch,
+  stackContext,
+  stackIssues,
+  stackPebblesComment,
+  stackPrBodySection,
+} from "./stack.mjs";
+
+test("builds ordered stack metadata and PR copy", () => {
+  const [first, second, third] = stackIssues(
+    [
+      { id: "repo-aaa", title: "A", branch: "picastle/repo-aaa-a" },
+      { id: "repo-bbb", title: "B", branch: "picastle/repo-bbb-b" },
+      { id: "repo-ccc", title: "C", branch: "picastle/repo-ccc-c" },
+    ],
+    "main",
+  );
+
+  assert.equal(stackBaseBranch(first!.stack), "main");
+  assert.equal(stackBaseBranch(second!.stack), "picastle/repo-aaa-a");
+  assert.deepEqual(third!.stack, {
+    stackId: "repo-aaa-repo-bbb-repo-ccc",
+    index: 3,
+    total: 3,
+    issueId: "repo-ccc",
+    headBranch: "picastle/repo-ccc-c",
+    baseBranch: "main",
+    previousBranch: "picastle/repo-bbb-b",
+  });
+
+  assert.match(stackContext(second!.stack), /position 2\/3/);
+  const section = stackPrBodySection(second!.stack);
+  assert.match(section, /<!-- picastle-stack/);
+  assert.match(section, /This PR is \*\*2 of 3\*\*/);
+  assert.deepEqual(parseStackMetadataFromBody(section), second!.stack);
+  assert.match(stackPebblesComment(second!.stack, "https://github.com/acme/repo/pull/2")!, /stacked PR 2\/3/);
+});
+
+test("retargets open stack PRs to the nearest previous open stack entry", () => {
+  const [first, second, third] = stackIssues(
+    [
+      { id: "repo-aaa", title: "A", branch: "picastle/repo-aaa-a" },
+      { id: "repo-bbb", title: "B", branch: "picastle/repo-bbb-b" },
+      { id: "repo-ccc", title: "C", branch: "picastle/repo-ccc-c" },
+    ],
+    "main",
+  );
+
+  assert.deepEqual(
+    planStackRetargets(
+      [
+        {
+          number: 2,
+          headRefName: second!.branch,
+          baseRefName: first!.branch,
+          url: "https://github.com/acme/repo/pull/2",
+          body: stackPrBodySection(second!.stack),
+        },
+        {
+          number: 3,
+          headRefName: third!.branch,
+          baseRefName: first!.branch,
+          url: "https://github.com/acme/repo/pull/3",
+          body: stackPrBodySection(third!.stack),
+        },
+      ],
+      "main",
+    ).map((action) => [action.prRef, action.currentBase, action.expectedBase]),
+    [
+      ["https://github.com/acme/repo/pull/2", first!.branch, "main"],
+      ["https://github.com/acme/repo/pull/3", first!.branch, second!.branch],
+    ],
+  );
+});
+
+test("ignores malformed or non-stack PR bodies when planning retargets", () => {
+  assert.equal(parseStackMetadataFromBody("<!-- picastle-stack\nnot json\n-->"), undefined);
+  assert.deepEqual(
+    planStackRetargets(
+      [
+        { number: 1, headRefName: "picastle/repo-aaa-a", baseRefName: "main", body: "no marker" },
+        { number: 2, headRefName: "picastle/repo-bbb-b", baseRefName: "main", body: "<!-- picastle-stack\n{}\n-->" },
+      ],
+      "main",
+    ),
+    [],
+  );
+});

--- a/pi/picastle/stack.test.mts
+++ b/pi/picastle/stack.test.mts
@@ -79,6 +79,47 @@ test("retargets open stack PRs to the nearest previous open stack entry", () => 
   );
 });
 
+test("refreshes next stack metadata to the next still-open PR", () => {
+  const [first, second, third] = stackIssues(
+    [
+      { id: "repo-aaa", title: "A", branch: "picastle/repo-aaa-a" },
+      { id: "repo-bbb", title: "B", branch: "picastle/repo-bbb-b" },
+      { id: "repo-ccc", title: "C", branch: "picastle/repo-ccc-c" },
+    ],
+    "main",
+  );
+
+  const actions = planStackRetargets(
+    [
+      {
+        number: 1,
+        headRefName: first!.branch,
+        baseRefName: "main",
+        url: "https://github.com/acme/repo/pull/1",
+        body: stackPrBodySection(first!.stack),
+      },
+      {
+        number: 3,
+        headRefName: third!.branch,
+        baseRefName: second!.branch,
+        url: "https://github.com/acme/repo/pull/3",
+        body: stackPrBodySection(third!.stack),
+      },
+    ],
+    "main",
+  );
+
+  assert.deepEqual(
+    actions.map((action) => [action.headRefName, action.expectedBase, action.stack.previousBranch, action.stack.nextBranch]),
+    [
+      [first!.branch, "main", undefined, third!.branch],
+      [third!.branch, first!.branch, first!.branch, undefined],
+    ],
+  );
+  assert.equal(actions[0]!.updateBase, false);
+  assert.equal(actions[0]!.updateBody, true);
+});
+
 test("ignores malformed or non-stack PR bodies when planning retargets", () => {
   assert.equal(parseStackMetadataFromBody("<!-- picastle-stack\nnot json\n-->"), undefined);
   assert.deepEqual(


### PR DESCRIPTION
> *This PR was produced by an autonomous Picastle run from the agent brief on pebbles issue dotfiles-fk7.*

## Summary

Implements the Picastle-selected pebbles issue:

- dotfiles-fk7: feat(picastle): add first-class stacked PR support

Review the original brief with:

```bash
peb --remote 'pi' -R 'dotfiles' show 'dotfiles-fk7'
```

## Verification

Picastle ran the configured verification step for the files changed by this branch before opening the PR.

Closes: dotfiles-fk7
